### PR TITLE
Adopt Liquid Glass design and optimize image loading

### DIFF
--- a/Microfiche/Services/ImageCache.swift
+++ b/Microfiche/Services/ImageCache.swift
@@ -30,6 +30,15 @@ class ImageCache {
     }
 
     func getImage(for url: URL, size: CGFloat) -> NSImage? {
+        if let image = cachedImage(for: url, size: size) {
+            PerformanceMonitor.shared.recordCacheHit()
+            return image
+        }
+        PerformanceMonitor.shared.recordCacheMiss()
+        return nil
+    }
+
+    private func cachedImage(for url: URL, size: CGFloat) -> NSImage? {
         let key = cacheKey(for: url, size: size)
 
         if let cachedImage = cache.object(forKey: key as NSString) {
@@ -41,12 +50,10 @@ class ImageCache {
             if let cacheAttributes = try? FileManager.default.attributesOfItem(atPath: cacheURL.path),
                let sourceAttributes = try? FileManager.default.attributesOfItem(atPath: url.path),
                let cacheModDate = cacheAttributes[.modificationDate] as? Date,
-               let sourceModDate = sourceAttributes[.modificationDate] as? Date {
-
-                if sourceModDate > cacheModDate {
-                    try? FileManager.default.removeItem(at: cacheURL)
-                    return nil
-                }
+               let sourceModDate = sourceAttributes[.modificationDate] as? Date,
+               sourceModDate > cacheModDate {
+                try? FileManager.default.removeItem(at: cacheURL)
+                return nil
             }
 
             cache.setObject(image, forKey: key as NSString)
@@ -63,6 +70,17 @@ class ImageCache {
         let cacheURL = cacheDirectory.appendingPathComponent(key)
         if let data = image.tiffRepresentation {
             try? data.write(to: cacheURL)
+        }
+    }
+
+    /// Loads and caches a thumbnail if not already present.
+    func preloadImage(for url: URL, size: CGFloat) {
+        if cachedImage(for: url, size: size) != nil { return }
+
+        DispatchQueue.global(qos: .utility).async { [weak self] in
+            guard let self else { return }
+            guard let image = ImageThumbnailGenerator.squareThumbnail(from: url, size: size) else { return }
+            self.setImage(image, for: url, size: size)
         }
     }
 

--- a/Microfiche/Services/ImagePrefetcher.swift
+++ b/Microfiche/Services/ImagePrefetcher.swift
@@ -18,15 +18,13 @@ enum ImagePrefetcher {
     ) {
         guard let currentIndex = imageFiles.firstIndex(where: { $0.id == file.id }) else { return }
 
-        // Prefetch thumbnails
+        // Prefetch thumbnails (decode + cache, not just lookup)
         let thumbEnd = min(currentIndex + 1 + thumbnailRange, imageFiles.count)
         for index in (currentIndex + 1)..<thumbEnd {
             let prefetchFile = imageFiles[index]
             let ext = prefetchFile.url.pathExtension.lowercased()
             if ext != "pdf" && ext != "svg" {
-                DispatchQueue.global(qos: .background).async {
-                    _ = ImageCache.shared.getImage(for: prefetchFile.url, size: thumbnailSize)
-                }
+                ImageCache.shared.preloadImage(for: prefetchFile.url, size: thumbnailSize)
             }
         }
 

--- a/Microfiche/Services/ImageThumbnailGenerator.swift
+++ b/Microfiche/Services/ImageThumbnailGenerator.swift
@@ -1,0 +1,65 @@
+//
+//  ImageThumbnailGenerator.swift
+//  Microfiche
+//
+//  Shared CGImageSource-based thumbnail generation for fast, memory-efficient decoding.
+//
+
+import AppKit
+import Foundation
+
+enum ImageThumbnailGenerator {
+    /// Generates a downsampled thumbnail without loading the full image into memory.
+    static func thumbnail(from url: URL, maxPixelSize: CGFloat) -> NSImage? {
+        guard let imageSource = CGImageSourceCreateWithURL(url as CFURL, nil) else {
+            return nil
+        }
+
+        let options: [CFString: Any] = [
+            kCGImageSourceCreateThumbnailFromImageAlways: true,
+            kCGImageSourceCreateThumbnailWithTransform: true,
+            kCGImageSourceThumbnailMaxPixelSize: maxPixelSize,
+            kCGImageSourceShouldCache: false
+        ]
+
+        guard let cgImage = CGImageSourceCreateThumbnailAtIndex(imageSource, 0, options as CFDictionary) else {
+            return nil
+        }
+
+        let width = CGFloat(cgImage.width)
+        let height = CGFloat(cgImage.height)
+        return NSImage(cgImage: cgImage, size: NSSize(width: width, height: height))
+    }
+
+    /// Produces a square-cropped thumbnail suitable for grid/list cells.
+    static func squareThumbnail(from url: URL, size: CGFloat) -> NSImage? {
+        guard let source = thumbnail(from: url, maxPixelSize: size * 2) else { return nil }
+
+        let targetSize = NSSize(width: size, height: size)
+        let thumbnail = NSImage(size: targetSize)
+
+        let imageAspect = source.size.width / max(source.size.height, 1)
+        let targetAspect: CGFloat = 1
+        var drawRect = NSRect(origin: .zero, size: targetSize)
+
+        if imageAspect > targetAspect {
+            let scaledHeight = targetSize.width / imageAspect
+            drawRect.origin.y = (targetSize.height - scaledHeight) / 2
+            drawRect.size = NSSize(width: targetSize.width, height: scaledHeight)
+        } else {
+            let scaledWidth = targetSize.height * imageAspect
+            drawRect.origin.x = (targetSize.width - scaledWidth) / 2
+            drawRect.size = NSSize(width: scaledWidth, height: targetSize.height)
+        }
+
+        thumbnail.lockFocus()
+        source.draw(
+            in: drawRect,
+            from: NSRect(origin: .zero, size: source.size),
+            operation: .copy,
+            fraction: 1.0
+        )
+        thumbnail.unlockFocus()
+        return thumbnail
+    }
+}

--- a/Microfiche/Services/PerformanceMonitor.swift
+++ b/Microfiche/Services/PerformanceMonitor.swift
@@ -27,4 +27,13 @@ class PerformanceMonitor: ObservableObject {
             self.cacheHits = 0
         }
     }
+
+    func recordCacheHit() {
+        totalRequests += 1
+        cacheHits += 1
+    }
+
+    func recordCacheMiss() {
+        totalRequests += 1
+    }
 }

--- a/Microfiche/Services/PreviewImageCache.swift
+++ b/Microfiche/Services/PreviewImageCache.swift
@@ -13,6 +13,7 @@ class PreviewImageCache {
 
     private let cache = NSCache<NSURL, NSImage>()
     private let processingQueue = DispatchQueue(label: "com.microfiche.previewcache", qos: .userInitiated, attributes: .concurrent)
+    private let loadSemaphore = DispatchSemaphore(value: 6)
 
     private init() {
         // Configure cache limits - store up to 100 preview images (roughly 2-5GB)
@@ -32,11 +33,12 @@ class PreviewImageCache {
             return
         }
 
-        // Load on background queue
+        // Load on background queue with bounded concurrency
         processingQueue.async { [weak self] in
             guard let self = self else { return }
+            self.loadSemaphore.wait()
+            defer { self.loadSemaphore.signal() }
 
-            // Load and decode image
             guard let image = self.loadAndOptimizeImage(from: url) else {
                 DispatchQueue.main.async {
                     completion?(nil)
@@ -55,44 +57,7 @@ class PreviewImageCache {
     }
 
     private func loadAndOptimizeImage(from url: URL) -> NSImage? {
-        guard let imageSource = CGImageSourceCreateWithURL(url as CFURL, nil) else {
-            return nil
-        }
-
-        // Get image properties without decoding
-        guard let properties = CGImageSourceCopyPropertiesAtIndex(imageSource, 0, nil) as? [String: Any],
-              let width = properties[kCGImagePropertyPixelWidth as String] as? CGFloat,
-              let height = properties[kCGImagePropertyPixelHeight as String] as? CGFloat else {
-            return NSImage(contentsOf: url)
-        }
-
-        // Calculate optimal size for preview (max 2000px on longest side)
-        let maxDimension: CGFloat = 2000
-        let scale: CGFloat
-        if max(width, height) > maxDimension {
-            scale = maxDimension / max(width, height)
-        } else {
-            scale = 1.0
-        }
-
-        let targetWidth = width * scale
-        let targetHeight = height * scale
-
-        // Create thumbnail with decoding
-        let options: [CFString: Any] = [
-            kCGImageSourceCreateThumbnailFromImageAlways: true,
-            kCGImageSourceCreateThumbnailWithTransform: true,
-            kCGImageSourceThumbnailMaxPixelSize: max(targetWidth, targetHeight),
-            kCGImageSourceShouldCache: false // We handle our own caching
-        ]
-
-        guard let cgImage = CGImageSourceCreateThumbnailAtIndex(imageSource, 0, options as CFDictionary) else {
-            return NSImage(contentsOf: url)
-        }
-
-        // Convert to NSImage
-        let nsImage = NSImage(cgImage: cgImage, size: NSSize(width: targetWidth, height: targetHeight))
-        return nsImage
+        ImageThumbnailGenerator.thumbnail(from: url, maxPixelSize: 2000)
     }
 
     func clearCache() {

--- a/Microfiche/Views/ImageDetailView.swift
+++ b/Microfiche/Views/ImageDetailView.swift
@@ -104,43 +104,44 @@ struct ImageDetailView: View {
     var body: some View {
         VStack(spacing: 0) {
             // Header
-            HStack {
-                Button(action: onBack) {
-                    HStack {
-                        Image(systemName: "chevron.left")
-                        Text("Back")
+            LiquidGlassPanel(cornerRadius: 0) {
+                HStack {
+                    Button(action: onBack) {
+                        HStack {
+                            Image(systemName: "chevron.left")
+                            Text("Back")
+                        }
+                    }
+                    .microficheIconButton()
+
+                    Spacer()
+
+                    Text(file.name)
+                        .font(.headline)
+                        .lineLimit(1)
+
+                    Spacer()
+
+                    HStack(spacing: 16) {
+                        Button(action: { saveMetadata() }) {
+                            Image(systemName: "square.and.arrow.down")
+                        }
+                        .microficheIconButton()
+                        .help("Save metadata")
+
+                        Button(action: {}) {
+                            Image(systemName: "square.and.arrow.up")
+                        }
+                        .microficheIconButton()
+
+                        Button(action: {}) {
+                            Image(systemName: "ellipsis.circle")
+                        }
+                        .microficheIconButton()
                     }
                 }
-                .buttonStyle(BorderlessButtonStyle())
-
-                Spacer()
-
-                Text(file.name)
-                    .font(.headline)
-                    .lineLimit(1)
-
-                Spacer()
-
-                HStack(spacing: 16) {
-                    Button(action: { saveMetadata() }) {
-                        Image(systemName: "square.and.arrow.down")
-                    }
-                    .buttonStyle(BorderlessButtonStyle())
-                    .help("Save metadata")
-
-                    Button(action: {}) {
-                        Image(systemName: "square.and.arrow.up")
-                    }
-                    .buttonStyle(BorderlessButtonStyle())
-
-                    Button(action: {}) {
-                        Image(systemName: "ellipsis.circle")
-                    }
-                    .buttonStyle(BorderlessButtonStyle())
-                }
+                .padding()
             }
-            .padding()
-            .background(Color(NSColor.controlBackgroundColor))
 
             Divider()
 
@@ -174,8 +175,9 @@ struct ImageDetailView: View {
                 Divider()
 
                 // Right side - Metadata
-                ScrollView {
-                    VStack(alignment: .leading, spacing: 24) {
+                LiquidGlassPanel(cornerRadius: 12) {
+                    ScrollView {
+                        VStack(alignment: .leading, spacing: 24) {
                         EditableChipSection(
                             title: "Tags",
                             itemName: "tag",
@@ -285,7 +287,8 @@ struct ImageDetailView: View {
                     .padding()
                 }
                 .frame(width: 300)
-                .background(Color(NSColor.controlBackgroundColor))
+                .padding(.trailing, 8)
+                .padding(.vertical, 8)
             }
         }
         .onAppear {

--- a/Microfiche/Views/LiquidGlassDesign.swift
+++ b/Microfiche/Views/LiquidGlassDesign.swift
@@ -1,0 +1,132 @@
+//
+//  LiquidGlassDesign.swift
+//  Microfiche
+//
+//  Liquid Glass design helpers with fallbacks for macOS 15+.
+//
+
+import SwiftUI
+
+// MARK: - Glass-Aware Buttons
+
+extension View {
+    @ViewBuilder
+    func microficheIconButton() -> some View {
+        if #available(macOS 26.0, *) {
+            self.buttonStyle(.glass)
+        } else {
+            self.buttonStyle(.borderless)
+        }
+    }
+}
+
+// MARK: - Selection Highlight
+
+extension View {
+    /// Sidebar/list selection — uses tint on glass sidebars to avoid glass-on-glass stacking.
+    @ViewBuilder
+    func sidebarSelectionBackground(isSelected: Bool, cornerRadius: CGFloat = 6) -> some View {
+        if isSelected {
+            self.background(
+                Color.accentColor.opacity(0.18),
+                in: RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+            )
+        } else {
+            self
+        }
+    }
+
+    /// Content-layer selection — safe to use Liquid Glass over non-glass content.
+    @ViewBuilder
+    func contentSelectionChrome(isSelected: Bool, cornerRadius: CGFloat = 10) -> some View {
+        let shape = RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+
+        if isSelected {
+            if #available(macOS 26.0, *) {
+                self
+                    .padding(4)
+                    .background {
+                        shape
+                            .fill(.clear)
+                            .glassEffect(.regular.tint(.accentColor).interactive(), in: shape)
+                    }
+            } else {
+                self
+                    .padding(6)
+                    .background(Color(NSColor.controlBackgroundColor), in: shape)
+                    .overlay(shape.stroke(Color.accentColor, lineWidth: 3))
+                    .shadow(color: Color.accentColor.opacity(0.35), radius: 8)
+            }
+        } else {
+            if #available(macOS 26.0, *) {
+                self.padding(4)
+            } else {
+                self
+                    .padding(6)
+                    .background(Color(NSColor.controlBackgroundColor), in: shape)
+                    .overlay(shape.stroke(Color(NSColor.separatorColor), lineWidth: 2))
+            }
+        }
+    }
+}
+
+// MARK: - Floating Panel
+
+struct LiquidGlassPanel<Content: View>: View {
+    let cornerRadius: CGFloat
+    let content: Content
+
+    init(cornerRadius: CGFloat = 16, @ViewBuilder content: () -> Content) {
+        self.cornerRadius = cornerRadius
+        self.content = content()
+    }
+
+    var body: some View {
+        let shape = RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+
+        if #available(macOS 26.0, *) {
+            content
+                .background {
+                    shape
+                        .fill(.clear)
+                        .glassEffect(.regular, in: shape)
+                }
+        } else {
+            content
+                .background(Color(NSColor.controlBackgroundColor), in: shape)
+                .overlay(shape.stroke(Color(NSColor.separatorColor), lineWidth: 2))
+        }
+    }
+}
+
+// MARK: - Navigation Chrome
+
+extension View {
+    /// Removes legacy toolbar backgrounds that interfere with the system scroll-edge glass effect.
+    @ViewBuilder
+    func microficheToolbarChrome() -> some View {
+        if #available(macOS 26.0, *) {
+            self
+        } else {
+            self
+                .toolbarBackground(Color(NSColor.textBackgroundColor), for: .windowToolbar)
+                .toolbarBackground(.visible, for: .windowToolbar)
+        }
+    }
+
+    /// Detail column background — defers to system glass on Tahoe, keeps legacy card on older macOS.
+    @ViewBuilder
+    func microficheDetailChrome() -> some View {
+        if #available(macOS 26.0, *) {
+            self
+                .background(Color(NSColor.windowBackgroundColor))
+        } else {
+            self
+                .background(Color(NSColor.controlBackgroundColor))
+                .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+                .shadow(color: Color.black.opacity(0.12), radius: 8, x: -2, y: 0)
+                .padding(.horizontal, 2)
+                .padding(.vertical, 2)
+        }
+    }
+}

--- a/Microfiche/Views/MainContentView.swift
+++ b/Microfiche/Views/MainContentView.swift
@@ -25,9 +25,6 @@ struct MainContentView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            Divider()
-                .background(Color(NSColor.separatorColor))
-
             VStack {
                 if imageFiles.isEmpty {
                     Spacer()
@@ -77,7 +74,7 @@ struct MainContentView: View {
                         Text(mode.rawValue).tag(mode)
                     }
                 }
-                .pickerStyle(SegmentedPickerStyle())
+                .pickerStyle(.segmented)
             }
 
             if viewMode == .grid {
@@ -87,20 +84,14 @@ struct MainContentView: View {
                             Text(size.rawValue).tag(size)
                         }
                     }
-                    .pickerStyle(SegmentedPickerStyle())
+                    .pickerStyle(.segmented)
                     .frame(width: 150)
                     .padding(.trailing)
                 }
             }
         }
-        .toolbarBackground(Color(NSColor.windowBackgroundColor), for: .windowToolbar)
-        .toolbarBackground(.visible, for: .windowToolbar)
-        .background(Color(NSColor.controlBackgroundColor))
-        .cornerRadius(12)
-        .shadow(color: Color.black.opacity(0.15), radius: 8, x: -2, y: 0)
-        .padding(.leading, 2)
-        .padding(.trailing, 2)
-        .padding(.vertical, 2)
+        .microficheToolbarChrome()
+        .microficheDetailChrome()
         .onChange(of: gridThumbnailSize) {
             updateColumns(for: lastKnownWidth)
         }
@@ -194,16 +185,7 @@ struct GridCell: View {
             FileThumbnailView(file: file, size: size, onRename: onRename)
                 .frame(width: size, height: size)
         }
-        .padding(6)
-        .background(
-            RoundedRectangle(cornerRadius: 10)
-                .fill(Color(NSColor.controlBackgroundColor))
-        )
-        .overlay(
-            RoundedRectangle(cornerRadius: 10)
-                .stroke(isSelected ? Color.accentColor : Color(NSColor.separatorColor), lineWidth: isSelected ? 4 : 3)
-        )
-        .shadow(color: isSelected ? Color.accentColor.opacity(0.4) : .clear, radius: isSelected ? 10 : 0)
+        .contentSelectionChrome(isSelected: isSelected)
         .contentShape(Rectangle())
         .onTapGesture(count: 2) { onDoubleClickImage(file.id) }
         .onTapGesture { onSelectImage(file.id) }
@@ -253,7 +235,7 @@ struct ImageListView: View {
                     }
                     .padding(.vertical, 2)
                     .contentShape(Rectangle())
-                    .background(selectedImageFileIDs.contains(file.id) ? Color.accentColor.opacity(0.2) : Color.clear)
+                    .sidebarSelectionBackground(isSelected: selectedImageFileIDs.contains(file.id))
                     .simultaneousGesture(
                         TapGesture(count: 1)
                             .onEnded { _ in onSelectImage(file.id) }

--- a/Microfiche/Views/PreviewView.swift
+++ b/Microfiche/Views/PreviewView.swift
@@ -16,39 +16,30 @@ struct PreviewView: View {
     var body: some View {
         GeometryReader { geometry in
             ZStack {
-                Color.black.opacity(0.8)
-                    .edgesIgnoringSafeArea(.all)
+                Color.black.opacity(0.72)
+                    .ignoresSafeArea()
                     .onTapGesture(perform: onDismiss)
 
-                VStack {
-                    ZStack {
-                        RoundedRectangle(cornerRadius: 16)
-                            .fill(Color(NSColor.controlBackgroundColor))
-                        RoundedRectangle(cornerRadius: 16)
-                            .stroke(Color(NSColor.separatorColor), lineWidth: 4)
-                        Group {
-                            if file.url.pathExtension.lowercased() == "pdf" {
-                                PDFKitView(url: file.url)
-                                    .frame(maxWidth: .infinity, maxHeight: .infinity)
-                            } else if file.url.pathExtension.lowercased() == "svg" {
-                                SVGImageView(url: file.url)
-                                    .frame(maxWidth: .infinity, maxHeight: .infinity)
-                                    .aspectRatio(contentMode: .fit)
-                            } else {
-                                if let image = previewImage {
-                                    Image(nsImage: image)
-                                        .resizable()
-                                        .aspectRatio(contentMode: .fit)
-                                } else if isLoading {
-                                    ProgressView()
-                                }
-                            }
+                LiquidGlassPanel(cornerRadius: 16) {
+                    Group {
+                        if file.url.pathExtension.lowercased() == "pdf" {
+                            PDFKitView(url: file.url)
+                                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                        } else if file.url.pathExtension.lowercased() == "svg" {
+                            SVGImageView(url: file.url)
+                                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                                .aspectRatio(contentMode: .fit)
+                        } else if let image = previewImage {
+                            Image(nsImage: image)
+                                .resizable()
+                                .aspectRatio(contentMode: .fit)
+                        } else if isLoading {
+                            ProgressView()
                         }
-                        .padding(32)
                     }
-                    .frame(width: geometry.size.width * 0.75, height: geometry.size.height * 0.75)
+                    .padding(32)
                 }
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .frame(width: geometry.size.width * 0.75, height: geometry.size.height * 0.75)
             }
         }
         .onAppear {

--- a/Microfiche/Views/SidebarView.swift
+++ b/Microfiche/Views/SidebarView.swift
@@ -31,7 +31,7 @@ struct SidebarView: View {
                 Button(action: onLinkFolder) {
                     Image(systemName: "plus")
                 }
-                .buttonStyle(BorderlessButtonStyle())
+                .microficheIconButton()
                 .help("Add Folder")
             }
             .padding([.top, .horizontal])
@@ -45,7 +45,7 @@ struct SidebarView: View {
                 .onTapGesture {
                     onSelect(.all)
                 }
-                .background(selection == .all ? Color.accentColor.opacity(0.2) : Color.clear)
+                .sidebarSelectionBackground(isSelected: selection == .all)
                 .listRowSeparator(.hidden)
 
                 ForEach(folderURLs, id: \.self) { url in
@@ -57,7 +57,7 @@ struct SidebarView: View {
                     .onTapGesture {
                         onSelect(.folder(url))
                     }
-                    .background(selection == .folder(url) ? Color.accentColor.opacity(0.2) : Color.clear)
+                    .sidebarSelectionBackground(isSelected: selection == .folder(url))
                     .listRowSeparator(.hidden)
                     .contextMenu {
                         Button("Remove Folder", role: .destructive) {
@@ -79,7 +79,7 @@ struct SidebarView: View {
                 Button(action: onCreateContactSheet) {
                     Image(systemName: "plus")
                 }
-                .buttonStyle(BorderlessButtonStyle())
+                .microficheIconButton()
                 .help("New Contact Sheet")
             }
             .padding([.horizontal])
@@ -110,7 +110,7 @@ struct SidebarView: View {
 
             Spacer()
         }
-        .background(Color(NSColor.windowBackgroundColor))
+        .navigationSplitViewColumnWidth(min: 180, ideal: 220)
     }
 }
 
@@ -161,7 +161,7 @@ struct ContactSheetSidebarItem: View {
                 onSelect()
             }
         }
-        .background(isSelected ? Color.accentColor.opacity(0.2) : Color.clear)
+        .sidebarSelectionBackground(isSelected: isSelected)
         .overlay(
             RoundedRectangle(cornerRadius: 4)
                 .stroke(isDropTargeted ? Color.accentColor : Color.clear, lineWidth: 2)

--- a/Microfiche/Views/ThumbnailViews.swift
+++ b/Microfiche/Views/ThumbnailViews.swift
@@ -49,7 +49,7 @@ struct OptimizedAsyncImage: View {
         hasError = false
 
         DispatchQueue.global(qos: .userInitiated).async {
-            let image = loadAndResizeImage()
+            let image = ImageThumbnailGenerator.squareThumbnail(from: url, size: size)
             DispatchQueue.main.async {
                 self.isLoading = false
                 if let image = image {
@@ -60,33 +60,6 @@ struct OptimizedAsyncImage: View {
                 }
             }
         }
-    }
-
-    private func loadAndResizeImage() -> NSImage? {
-        guard let sourceImage = NSImage(contentsOf: url) else { return nil }
-        let targetSize = NSSize(width: size, height: size)
-        let thumbnail = NSImage(size: targetSize)
-
-        let imageAspect = sourceImage.size.width / sourceImage.size.height
-        let targetAspect = targetSize.width / targetSize.height
-        var drawRect = NSRect(origin: .zero, size: targetSize)
-        if imageAspect > targetAspect {
-            let scaledHeight = targetSize.width / imageAspect
-            drawRect.origin.y = (targetSize.height - scaledHeight) / 2
-            drawRect.size = NSSize(width: targetSize.width, height: scaledHeight)
-        } else {
-            let scaledWidth = targetSize.height * imageAspect
-            drawRect.origin.x = (targetSize.width - scaledWidth) / 2
-            drawRect.size = NSSize(width: scaledWidth, height: targetSize.height)
-        }
-
-        thumbnail.lockFocus()
-        sourceImage.draw(in: drawRect,
-                         from: NSRect(origin: .zero, size: sourceImage.size),
-                         operation: .copy,
-                         fraction: 1.0)
-        thumbnail.unlockFocus()
-        return thumbnail
     }
 }
 

--- a/MicroficheTests/MicroficheTests.swift
+++ b/MicroficheTests/MicroficheTests.swift
@@ -18,12 +18,37 @@ final class MicroficheTests: XCTestCase {
         // Put teardown code here. This method is called after the invocation of each test method in the class.
     }
 
-    func testExample() throws {
-        // This is an example of a functional test case.
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
-        // Any test you write for XCTest can be annotated as throws and async.
-        // Mark your test throws to produce an unexpected failure when your test encounters an uncaught error.
-        // Mark your test async to allow awaiting for asynchronous code to complete. Check the results with assertions afterwards.
+    func testSquareThumbnailFromPNG() throws {
+        let pngData = Data(base64Encoded:
+            "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="
+        )!
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("microfiche-test.png")
+        try pngData.write(to: url)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let thumbnail = ImageThumbnailGenerator.squareThumbnail(from: url, size: 40)
+        XCTAssertNotNil(thumbnail)
+        XCTAssertEqual(thumbnail?.size.width, 40)
+        XCTAssertEqual(thumbnail?.size.height, 40)
+    }
+
+    func testImageCachePreloadPopulatesMemory() throws {
+        let pngData = Data(base64Encoded:
+            "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="
+        )!
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("microfiche-cache-test.png")
+        try pngData.write(to: url)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let expectation = expectation(description: "preload completes")
+        ImageCache.shared.preloadImage(for: url, size: 40)
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
+            XCTAssertNotNil(ImageCache.shared.getImage(for: url, size: 40))
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: 3.0)
     }
 
     func testPerformanceExample() throws {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Modernizes Microfiche for Apple's Liquid Glass design language (macOS Tahoe 26) while keeping graceful fallbacks on macOS 15+, and improves image loading performance across the board.

## Liquid Glass UI

- Added `LiquidGlassDesign.swift` with reusable helpers for glass panels, toolbar chrome, and selection states
- **Navigation layer**: Removed custom toolbar backgrounds and card elevation that interfere with the system scroll-edge glass effect on macOS 26
- **Sidebar**: Uses tint-based selection (avoids glass-on-glass stacking on the system glass sidebar)
- **Content layer**: Grid selection, preview overlay, detail header, and metadata inspector use `glassEffect` on macOS 26
- **Buttons**: Icon actions adopt `.glass` button style on macOS 26 with borderless fallback

## Performance

- **Shared thumbnail pipeline**: New `ImageThumbnailGenerator` uses `CGImageSource` downsampling instead of loading full images into memory
- **Fixed prefetch bug**: `ImagePrefetcher` now decodes and caches thumbnails instead of only checking the cache
- **Bounded concurrency**: Preview preloading limited to 6 concurrent decodes to avoid CPU spikes on large libraries
- **Cache metrics**: `PerformanceMonitor` now tracks hit/miss rates accurately

## Testing

- Added unit tests for thumbnail generation and cache preload behavior

## Notes

Build and run on macOS Tahoe (Xcode 26 SDK) to see the full Liquid Glass treatment. On macOS 15 the app retains the previous elevated-card aesthetic via availability-gated fallbacks.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a0bc14a7-90dc-48d8-b6a7-a038b0a5691b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a0bc14a7-90dc-48d8-b6a7-a038b0a5691b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

