### PR TITLE
Add subtle hover animations to grid and list cells

### DIFF
--- a/Microfiche/Views/LiquidGlassDesign.swift
+++ b/Microfiche/Views/LiquidGlassDesign.swift
@@ -70,6 +70,59 @@ extension View {
     }
 }
 
+// MARK: - Hover Dynamics
+
+private extension Animation {
+    static let microficheHover = Animation.easeOut(duration: 0.18)
+}
+
+extension View {
+    /// Subtle lift and highlight when hovering grid content cells.
+    @ViewBuilder
+    func contentHoverDynamics(isHovered: Bool, isSelected: Bool, cornerRadius: CGFloat = 10) -> some View {
+        let shape = RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+        let scale: CGFloat = isHovered ? (isSelected ? 1.01 : 1.02) : 1.0
+
+        self
+            .scaleEffect(scale, anchor: .center)
+            .background {
+                if isHovered && !isSelected {
+                    shape.fill(Color.primary.opacity(0.05))
+                }
+            }
+            .overlay {
+                if isHovered {
+                    shape.stroke(
+                        isSelected ? Color.accentColor.opacity(0.35) : Color.primary.opacity(0.1),
+                        lineWidth: 1
+                    )
+                }
+            }
+            .shadow(
+                color: Color.black.opacity(isHovered ? 0.08 : 0),
+                radius: isHovered ? 8 : 0,
+                y: isHovered ? 3 : 0
+            )
+            .animation(.microficheHover, value: isHovered)
+    }
+
+    /// Subtle background tint for sidebar/list rows on hover.
+    @ViewBuilder
+    func sidebarHoverBackground(isHovered: Bool, isSelected: Bool, cornerRadius: CGFloat = 6) -> some View {
+        let shape = RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+
+        self
+            .background {
+                if isHovered && !isSelected {
+                    shape.fill(Color.primary.opacity(0.06))
+                } else if isHovered && isSelected {
+                    shape.fill(Color.accentColor.opacity(0.24))
+                }
+            }
+            .animation(.microficheHover, value: isHovered)
+    }
+}
+
 // MARK: - Floating Panel
 
 struct LiquidGlassPanel<Content: View>: View {

--- a/Microfiche/Views/MainContentView.swift
+++ b/Microfiche/Views/MainContentView.swift
@@ -179,6 +179,7 @@ struct GridCell: View {
     let onRename: (URL, String) -> Void
     let contactSheets: [ContactSheet]
     let onAddToContactSheet: (UUID, URL) -> Void
+    @State private var isHovered = false
 
     var body: some View {
         VStack {
@@ -186,7 +187,9 @@ struct GridCell: View {
                 .frame(width: size, height: size)
         }
         .contentSelectionChrome(isSelected: isSelected)
+        .contentHoverDynamics(isHovered: isHovered, isSelected: isSelected)
         .contentShape(Rectangle())
+        .onHover { isHovered = $0 }
         .onTapGesture(count: 2) { onDoubleClickImage(file.id) }
         .onTapGesture { onSelectImage(file.id) }
         .contextMenu {
@@ -217,32 +220,12 @@ struct ImageListView: View {
         ScrollViewReader { proxy in
             List {
                 ForEach(imageFiles) { file in
-                    HStack {
-                        FileThumbnailView(file: file, size: 40, onRename: onRename)
-                            .frame(width: 40, height: 40)
-                            .background(Color.gray.opacity(0.1))
-                            .cornerRadius(6)
-                        VStack(alignment: .leading) {
-                            EditableFileNameView(file: file, onRename: onRename)
-                                .font(.body)
-                                .lineLimit(1)
-                            Text(file.url.path)
-                                .font(.caption2)
-                                .foregroundColor(.secondary)
-                                .lineLimit(1)
-                        }
-                        Spacer()
-                    }
-                    .padding(.vertical, 2)
-                    .contentShape(Rectangle())
-                    .sidebarSelectionBackground(isSelected: selectedImageFileIDs.contains(file.id))
-                    .simultaneousGesture(
-                        TapGesture(count: 1)
-                            .onEnded { _ in onSelectImage(file.id) }
-                    )
-                    .simultaneousGesture(
-                        TapGesture(count: 2)
-                            .onEnded { _ in onDoubleClickImage(file.id) }
+                    ImageListRow(
+                        file: file,
+                        isSelected: selectedImageFileIDs.contains(file.id),
+                        onSelectImage: onSelectImage,
+                        onDoubleClickImage: onDoubleClickImage,
+                        onRename: onRename
                     )
                     .id(file.id)
                     .onAppear {
@@ -265,6 +248,49 @@ struct ImageListView: View {
                 }
             }
         }
+    }
+}
+
+// MARK: - List Row
+
+struct ImageListRow: View {
+    let file: ImageFile
+    let isSelected: Bool
+    let onSelectImage: (UUID) -> Void
+    let onDoubleClickImage: (UUID) -> Void
+    let onRename: (URL, String) -> Void
+    @State private var isHovered = false
+
+    var body: some View {
+        HStack {
+            FileThumbnailView(file: file, size: 40, onRename: onRename)
+                .frame(width: 40, height: 40)
+                .background(Color.gray.opacity(0.1))
+                .cornerRadius(6)
+            VStack(alignment: .leading) {
+                EditableFileNameView(file: file, onRename: onRename)
+                    .font(.body)
+                    .lineLimit(1)
+                Text(file.url.path)
+                    .font(.caption2)
+                    .foregroundColor(.secondary)
+                    .lineLimit(1)
+            }
+            Spacer()
+        }
+        .padding(.vertical, 2)
+        .contentShape(Rectangle())
+        .sidebarSelectionBackground(isSelected: isSelected)
+        .sidebarHoverBackground(isHovered: isHovered, isSelected: isSelected)
+        .onHover { isHovered = $0 }
+        .simultaneousGesture(
+            TapGesture(count: 1)
+                .onEnded { _ in onSelectImage(file.id) }
+        )
+        .simultaneousGesture(
+            TapGesture(count: 2)
+                .onEnded { _ in onDoubleClickImage(file.id) }
+        )
     }
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds subtle hover feedback when moving the pointer over image grid cells and list rows. Merged with latest `main`.

## Merge resolution

- **`GridCell`**: Kept Option A — Liquid Glass `contentSelectionChrome` + `contentHoverDynamics` + tap gestures (not `main`'s Button-based cell).
- **`ImageListRow`**: Kept extracted row + hover; adopted `main`'s selection fill, `listRowBackground(Color.clear)`, and `scrollContentBackground(.hidden)`.

## Changes

- **`LiquidGlassDesign.swift`**: New reusable modifiers:
  - `contentHoverDynamics` — gentle scale (1.02 unselected / 1.01 selected), soft tint, border highlight, shadow lift
  - `sidebarHoverBackground` — light background tint for list rows on hover
- **`MainContentView.swift`**:
  - `GridCell` tracks hover via `onHover` and applies `contentHoverDynamics`
  - `ImageListRow` with matching hover behavior for list view mode

## Testing

- [ ] Build and run on macOS
- [ ] Hover grid cells — confirm lift, tint, and smooth animation
- [ ] Hover list rows — confirm background tint
- [ ] Verify selection and double-click still work as before
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ed6bd-d1bc-7cc0-af15-2de338912efe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ed6bd-d1bc-7cc0-af15-2de338912efe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

