### PR TITLE
Make thumbnail size slider resizing smooth

### DIFF
--- a/Microfiche/ContentView.swift
+++ b/Microfiche/ContentView.swift
@@ -26,6 +26,10 @@ enum GridThumbnailSizing {
     static let minimum: CGFloat = 80
     static let defaultValue: CGFloat = 120
     static let maximum: CGFloat = 180
+
+    /// Decode once at the largest grid size so the size slider only changes
+    /// layout frames and can scale already-resident bitmaps without reloading.
+    static var decodeSize: CGFloat { maximum }
 }
 
 enum ArrowDirection {

--- a/Microfiche/Views/MainContentView.swift
+++ b/Microfiche/Views/MainContentView.swift
@@ -24,6 +24,12 @@ struct MainContentView: View {
     let contactSheets: [ContactSheet]
     let onAddToContactSheet: (UUID, URL) -> Void
     @State private var isResizingGrid = false
+    /// Local size used while dragging so slider updates don't rebuild ContentView each tick.
+    @State private var liveGridThumbnailSize: CGFloat?
+
+    private var displayedGridThumbnailSize: CGFloat {
+        liveGridThumbnailSize ?? gridThumbnailSize
+    }
 
     var body: some View {
         ZStack {
@@ -46,7 +52,7 @@ struct MainContentView: View {
                                 selectedImageFileIDs: $selectedImageFileIDs,
                                 onSelectImage: onSelectImage,
                                 onDoubleClickImage: onDoubleClickImage,
-                                thumbnailSize: gridThumbnailSize,
+                                thumbnailSize: displayedGridThumbnailSize,
                                 isResizing: isResizingGrid,
                                 scrollToID: $scrollToID,
                                 columnCount: $gridColumnCount,
@@ -90,13 +96,13 @@ struct MainContentView: View {
                             .foregroundStyle(.secondary)
 
                         Slider(
-                            value: $gridThumbnailSize,
+                            value: gridThumbnailSizeBinding,
                             in: GridThumbnailSizing.minimum...GridThumbnailSizing.maximum,
                             onEditingChanged: handleGridResize
                         )
                         .frame(width: 110)
                         .accessibilityLabel("Thumbnail size")
-                        .accessibilityValue("\(Int(gridThumbnailSize.rounded())) points")
+                        .accessibilityValue("\(Int(displayedGridThumbnailSize.rounded())) points")
 
                         Image(systemName: "photo.fill")
                             .font(.system(size: 15))
@@ -110,6 +116,20 @@ struct MainContentView: View {
         }
         .toolbarBackground(Color(NSColor.windowBackgroundColor), for: .windowToolbar)
         .toolbarBackground(.visible, for: .windowToolbar)
+    }
+
+    private var gridThumbnailSizeBinding: Binding<CGFloat> {
+        Binding(
+            get: { displayedGridThumbnailSize },
+            set: { newValue in
+                liveGridThumbnailSize = newValue
+                // Keep parent state frozen while dragging so ContentView doesn't
+                // rebuild on every slider tick. Non-drag updates write through.
+                if !isResizingGrid {
+                    gridThumbnailSize = newValue
+                }
+            }
+        )
     }
 
     private var mainCanvasBackground: some View {
@@ -136,9 +156,21 @@ struct MainContentView: View {
     }
 
     private func handleGridResize(_ isEditing: Bool) {
-        isResizingGrid = isEditing
+        if isEditing {
+            isResizingGrid = true
+            if liveGridThumbnailSize == nil {
+                liveGridThumbnailSize = gridThumbnailSize
+            }
+            return
+        }
 
-        if !isEditing, let selectedID = selectedImageFileIDs.first {
+        if let liveGridThumbnailSize {
+            gridThumbnailSize = liveGridThumbnailSize
+        }
+        liveGridThumbnailSize = nil
+        isResizingGrid = false
+
+        if let selectedID = selectedImageFileIDs.first {
             DispatchQueue.main.async {
                 scrollToID = selectedID
             }
@@ -244,6 +276,7 @@ struct ImageGridView: View {
                                 file: file,
                                 isSelected: selectedImageFileIDs.contains(file.id),
                                 size: thumbnailSize,
+                                isResizing: isResizing,
                                 aspectRatio: Layout.aspectRatio,
                                 onSelectImage: onSelectImage,
                                 onDoubleClickImage: onDoubleClickImage,
@@ -253,10 +286,11 @@ struct ImageGridView: View {
                             )
                             .id(file.id)
                             .onAppear {
+                                guard !isResizing else { return }
                                 ImagePrefetcher.prefetchNearby(
                                     for: file,
                                     in: imageFiles,
-                                    thumbnailSize: thumbnailSize
+                                    thumbnailSize: GridThumbnailSizing.decodeSize
                                 )
                             }
                         }
@@ -274,6 +308,11 @@ struct ImageGridView: View {
                 .onChange(of: thumbnailSize) {
                     updateColumnCount(for: geometry.size.width)
                 }
+                .onChange(of: isResizing) { _, resizing in
+                    if !resizing {
+                        updateColumnCount(for: geometry.size.width)
+                    }
+                }
                 .onChange(of: scrollToID) { _, newID in
                     if let id = newID {
                         withAnimation(.easeInOut(duration: 0.2)) {
@@ -287,6 +326,7 @@ struct ImageGridView: View {
         .transaction { transaction in
             if isResizing {
                 transaction.animation = nil
+                transaction.disablesAnimations = true
             }
         }
         .animation(isResizing ? nil : .snappy(duration: 0.22), value: thumbnailSize)
@@ -294,6 +334,10 @@ struct ImageGridView: View {
 
     private func updateColumnCount(for width: CGFloat) {
         guard width > 0 else { return }
+        // Avoid pushing column-count changes into ContentView on every drag tick.
+        // Layout still uses the live thumbnail width locally via LazyVGrid columns.
+        guard !isResizing else { return }
+
         let count = Layout.columnCount(
             availableWidth: width,
             thumbnailWidth: thumbnailSize
@@ -310,6 +354,7 @@ struct GridCell: View {
     let file: ImageFile
     let isSelected: Bool
     let size: CGFloat
+    let isResizing: Bool
     let aspectRatio: CGFloat
     let onSelectImage: (UUID) -> Void
     let onDoubleClickImage: (UUID) -> Void
@@ -322,14 +367,25 @@ struct GridCell: View {
         FileThumbnailView(
             file: file,
             size: size,
+            decodeSize: GridThumbnailSizing.decodeSize,
             aspectRatio: aspectRatio,
+            isResizing: isResizing,
             onRename: onRename
         )
         .frame(width: size, height: size / aspectRatio)
         .contentSelectionChrome(isSelected: isSelected)
-        .contentHoverDynamics(isHovered: isHovered, isSelected: isSelected)
+        .contentHoverDynamics(
+            isHovered: isResizing ? false : isHovered,
+            isSelected: isSelected
+        )
         .contentShape(Rectangle())
-        .onHover { isHovered = $0 }
+        .onHover { hovering in
+            guard !isResizing else {
+                isHovered = false
+                return
+            }
+            isHovered = hovering
+        }
         .onTapGesture(count: 2) { onDoubleClickImage(file.id) }
         .onTapGesture { onSelectImage(file.id) }
         .onDrag {

--- a/Microfiche/Views/ThumbnailViews.swift
+++ b/Microfiche/Views/ThumbnailViews.swift
@@ -12,16 +12,20 @@ import SwiftUI
 struct OptimizedAsyncImage: View {
     let url: URL
     let size: CGFloat
+    var decodeSize: CGFloat? = nil
+    var isResizing: Bool = false
+
     @State private var image: NSImage?
     @State private var isLoading = false
     @State private var hasError = false
+    @State private var activeDecodeSize: CGFloat?
 
     var body: some View {
         Group {
             if let image {
                 Image(nsImage: image)
                     .resizable()
-                    .interpolation(.medium)
+                    .interpolation(isResizing ? .low : .medium)
                     .aspectRatio(contentMode: .fit)
             } else if hasError {
                 Image(systemName: "photo")
@@ -31,6 +35,16 @@ struct OptimizedAsyncImage: View {
                 thumbnailPlaceholder
             }
         }
+        .onAppear(perform: syncActiveDecodeSize)
+        .onChange(of: size) { _, _ in
+            syncActiveDecodeSize()
+        }
+        .onChange(of: decodeSize) { _, _ in
+            syncActiveDecodeSize()
+        }
+        .onChange(of: isResizing) { _, _ in
+            syncActiveDecodeSize()
+        }
         .task(id: cacheIdentity) {
             await MainActor.run {
                 loadImage()
@@ -38,8 +52,12 @@ struct OptimizedAsyncImage: View {
         }
     }
 
+    private var resolvedDecodeSize: CGFloat {
+        activeDecodeSize ?? decodeSize ?? size
+    }
+
     private var cacheIdentity: String {
-        "\(url.path)|\(Int(size.rounded()))"
+        "\(url.path)|\(Int(resolvedDecodeSize.rounded()))"
     }
 
     private var thumbnailPlaceholder: some View {
@@ -51,8 +69,25 @@ struct OptimizedAsyncImage: View {
             )
     }
 
+    private func syncActiveDecodeSize() {
+        let target = decodeSize ?? size
+
+        if isResizing {
+            if activeDecodeSize == nil {
+                activeDecodeSize = target
+            }
+            return
+        }
+
+        if activeDecodeSize != target {
+            activeDecodeSize = target
+        }
+    }
+
     private func loadImage() {
-        if let cachedImage = ImageCache.shared.getImage(for: url, size: size) {
+        let requestSize = resolvedDecodeSize
+
+        if let cachedImage = ImageCache.shared.getImage(for: url, size: requestSize) {
             image = cachedImage
             hasError = false
             isLoading = false
@@ -64,12 +99,12 @@ struct OptimizedAsyncImage: View {
         isLoading = true
         hasError = false
 
-        ImageCache.shared.loadImage(for: url, size: size) { loadedImage in
+        ImageCache.shared.loadImage(for: url, size: requestSize) { loadedImage in
             isLoading = false
 
             if let loadedImage {
                 image = loadedImage
-            } else {
+            } else if image == nil {
                 hasError = true
             }
         }
@@ -81,18 +116,24 @@ struct OptimizedAsyncImage: View {
 struct FileThumbnailView: View {
     let file: ImageFile
     let size: CGFloat
+    let decodeSize: CGFloat?
     let aspectRatio: CGFloat
+    let isResizing: Bool
     let onRename: (URL, String) -> Void
 
     init(
         file: ImageFile,
         size: CGFloat,
+        decodeSize: CGFloat? = nil,
         aspectRatio: CGFloat = 1,
+        isResizing: Bool = false,
         onRename: @escaping (URL, String) -> Void
     ) {
         self.file = file
         self.size = size
+        self.decodeSize = decodeSize
         self.aspectRatio = aspectRatio
+        self.isResizing = isResizing
         self.onRename = onRename
     }
 
@@ -102,8 +143,13 @@ struct FileThumbnailView: View {
         ZStack {
             Color(NSColor.controlBackgroundColor)
 
-            OptimizedAsyncImage(url: file.url, size: size)
-                .frame(width: size, height: height)
+            OptimizedAsyncImage(
+                url: file.url,
+                size: size,
+                decodeSize: decodeSize,
+                isResizing: isResizing
+            )
+            .frame(width: size, height: height)
         }
         .frame(width: size, height: height)
         .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))

--- a/MicroficheTests/MicroficheTests.swift
+++ b/MicroficheTests/MicroficheTests.swift
@@ -63,6 +63,12 @@ final class MicroficheTests: XCTestCase {
         )
     }
 
+    func testGridThumbnailDecodeSizeIsStableAcrossSliderRange() {
+        XCTAssertEqual(GridThumbnailSizing.decodeSize, GridThumbnailSizing.maximum)
+        XCTAssertGreaterThanOrEqual(GridThumbnailSizing.decodeSize, GridThumbnailSizing.minimum)
+        XCTAssertGreaterThanOrEqual(GridThumbnailSizing.decodeSize, GridThumbnailSizing.defaultValue)
+    }
+
     func testGridNavigationMovesByCurrentColumnCount() {
         XCTAssertEqual(
             ImageNavigation.nextIndex(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Dragging the grid thumbnail size slider now feels continuous instead of hitching on every tick.

### Changes
- Decode grid thumbnails once at the max grid size (`180`) and only change layout frames while dragging, so existing bitmaps scale instead of reloading.
- Keep live slider values in `MainContentView` local state during drag so `ContentView` is not rebuilt on every tick.
- Disable hover dynamics, prefetch, and parent column-count writes while resizing; commit size/column count when the gesture ends.
- Add a unit test that the grid decode size stays stable at the maximum.

### Notes
Unable to run the macOS test target in this Linux cloud environment (no Xcode/Swift toolchain).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f78be-ee2f-715f-89a9-6dcfad4f4f1d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f78be-ee2f-715f-89a9-6dcfad4f4f1d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

