### PR TITLE
Fix durable local tags and notes persistence

### DIFF
--- a/Microfiche/ContentView.swift
+++ b/Microfiche/ContentView.swift
@@ -568,15 +568,18 @@ struct ContentView: View {
             .compactMap { file in originalFilesSnapshot.firstIndex(of: file) }
             .min()
 
+        var trashedURLs: [URL] = []
         for file in files {
             do {
                 try FileManager.default.trashItem(at: file.url, resultingItemURL: nil)
                 imageFiles.removeAll { $0.id == file.id }
                 selectedImageFileIDs.remove(file.id)
+                trashedURLs.append(file.url)
             } catch {
                 print("Error moving file to trash: \(error)")
             }
         }
+        ImageMetadataStore.shared.remove(for: trashedURLs)
 
         if let deletedDetailIndex {
             let nextIndex = min(deletedDetailIndex, imageFiles.count - 1)
@@ -713,10 +716,24 @@ struct ContentView: View {
         let newURL = oldURL.deletingLastPathComponent().appendingPathComponent(newName)
         do {
             try FileManager.default.moveItem(at: oldURL, to: newURL)
+            ImageMetadataStore.shared.move(from: oldURL, to: newURL)
+
             if let index = imageFiles.firstIndex(where: { $0.url == oldURL }) {
-                imageFiles[index] = ImageFile(id: imageFiles[index].id, url: newURL)
-                if detailViewFile?.id == imageFiles[index].id {
-                    detailViewFile = imageFiles[index]
+                let oldID = imageFiles[index].id
+                let renamedFile = ImageFile(url: newURL)
+                imageFiles[index] = renamedFile
+
+                if selectedImageFileIDs.remove(oldID) != nil {
+                    selectedImageFileIDs.insert(renamedFile.id)
+                }
+                if focusedImageFileID == oldID {
+                    focusedImageFileID = renamedFile.id
+                }
+                if scrollToID == oldID {
+                    scrollToID = renamedFile.id
+                }
+                if detailViewFile?.id == oldID {
+                    detailViewFile = renamedFile
                 }
             }
         } catch {

--- a/Microfiche/Extensions/URL+ExtendedAttributes.swift
+++ b/Microfiche/Extensions/URL+ExtendedAttributes.swift
@@ -72,20 +72,3 @@ extension URL {
         }
     }
 }
-
-extension URL {
-    func setFinderComment(_ comment: String) throws {
-        let key = "com.apple.metadata:kMDItemFinderComment"
-        let plist = try PropertyListSerialization.data(fromPropertyList: comment, format: .binary, options: 0)
-        try self.setExtendedAttribute(plist, forName: key)
-    }
-    
-    func setFinderTagsAndLabels(tags: [String], labels: [String]) throws {
-        let key = "com.apple.metadata:_kMDItemUserTags"
-        // Finder color tags are just special strings (e.g., 'Red', 'Orange', etc.)
-        // We'll append them to the tags array
-        let allTags = tags + labels
-        let plist = try PropertyListSerialization.data(fromPropertyList: allTags, format: .binary, options: 0)
-        try self.setExtendedAttribute(plist, forName: key)
-    }
-}

--- a/Microfiche/Models/ImageFile.swift
+++ b/Microfiche/Models/ImageFile.swift
@@ -12,17 +12,17 @@ struct ImageFile: Identifiable, Equatable, Hashable {
     let url: URL
     var name: String { url.lastPathComponent }
 
-    init(id: UUID = UUID(), url: URL) {
-        self.id = id
-        self.url = url
+    init(url: URL) {
+        let normalizedURL = url.standardizedFileURL
+        self.url = normalizedURL
+        self.id = ImageIdentity.stableID(for: normalizedURL)
     }
-    
+
     static func == (lhs: ImageFile, rhs: ImageFile) -> Bool {
-        lhs.id == rhs.id && lhs.url == rhs.url
+        lhs.id == rhs.id
     }
-    
+
     func hash(into hasher: inout Hasher) {
         hasher.combine(id)
-        hasher.combine(url)
     }
 }

--- a/Microfiche/Models/ImageIdentity.swift
+++ b/Microfiche/Models/ImageIdentity.swift
@@ -1,0 +1,28 @@
+//
+//  ImageIdentity.swift
+//  Microfiche
+//
+//  Deterministic identity for library images so metadata survives rescans.
+//
+
+import CryptoKit
+import Foundation
+
+enum ImageIdentity {
+    /// Stable identity derived from the file's normalized path.
+    static func stableID(for url: URL) -> UUID {
+        let digest = SHA256.hash(data: Data(normalizedPath(for: url).utf8))
+        let bytes = Array(digest.prefix(16))
+        return UUID(uuid: (
+            bytes[0], bytes[1], bytes[2], bytes[3],
+            bytes[4], bytes[5], bytes[6], bytes[7],
+            bytes[8], bytes[9], bytes[10], bytes[11],
+            bytes[12], bytes[13], bytes[14], bytes[15]
+        ))
+    }
+
+    /// Canonical path used for identity and local metadata keys.
+    static func normalizedPath(for url: URL) -> String {
+        url.standardizedFileURL.resolvingSymlinksInPath().path
+    }
+}

--- a/Microfiche/Models/ImageMetadata.swift
+++ b/Microfiche/Models/ImageMetadata.swift
@@ -1,0 +1,48 @@
+//
+//  ImageMetadata.swift
+//  Microfiche
+//
+//  Locally stored organization metadata for a library image.
+//
+
+import Foundation
+
+struct ImageMetadata: Codable, Equatable, Sendable {
+    var tags: [String]
+    var labels: [String]
+    var comments: String
+    var whereFrom: String
+
+    static let empty = ImageMetadata(
+        tags: [],
+        labels: [],
+        comments: "",
+        whereFrom: ""
+    )
+
+    var isEmpty: Bool {
+        tags.isEmpty
+            && labels.isEmpty
+            && comments.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            && whereFrom.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    mutating func normalized() {
+        tags = Self.normalizeList(tags)
+        labels = Self.normalizeList(labels)
+        comments = comments.trimmingCharacters(in: .whitespacesAndNewlines)
+        whereFrom = whereFrom.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private static func normalizeList(_ values: [String]) -> [String] {
+        var seen = Set<String>()
+        var result: [String] = []
+        for value in values {
+            let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty, !seen.contains(trimmed) else { continue }
+            seen.insert(trimmed)
+            result.append(trimmed)
+        }
+        return result
+    }
+}

--- a/Microfiche/Services/ImageMetadataStore.swift
+++ b/Microfiche/Services/ImageMetadataStore.swift
@@ -1,0 +1,160 @@
+//
+//  ImageMetadataStore.swift
+//  Microfiche
+//
+//  Local JSON persistence for tags, labels, comments, and source notes.
+//  Metadata is stored in Application Support (not written into image files).
+//
+
+import Foundation
+
+@MainActor
+final class ImageMetadataStore {
+    static let shared = ImageMetadataStore()
+
+    private let fileManager: FileManager
+    private let persistenceURL: URL
+    private var records: [String: ImageMetadata] = [:]
+
+    init(
+        persistenceURL customPersistenceURL: URL? = nil,
+        fileManager: FileManager = .default
+    ) {
+        self.fileManager = fileManager
+
+        let applicationSupport = fileManager.urls(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask
+        ).first!
+        let libraryDirectory = applicationSupport.appendingPathComponent(
+            "Microfiche",
+            isDirectory: true
+        )
+        persistenceURL = customPersistenceURL
+            ?? libraryDirectory.appendingPathComponent("image-metadata.json")
+
+        try? fileManager.createDirectory(
+            at: persistenceURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+
+        load()
+    }
+
+    func metadata(for url: URL) -> ImageMetadata {
+        let key = ImageIdentity.normalizedPath(for: url)
+        if let stored = records[key] {
+            return stored
+        }
+
+        // One-time migration from earlier Microfiche xattr attempts.
+        if let migrated = migrateLegacyExtendedAttributes(from: url) {
+            records[key] = migrated
+            persist()
+            return migrated
+        }
+
+        return .empty
+    }
+
+    func save(_ metadata: ImageMetadata, for url: URL) {
+        var normalized = metadata
+        normalized.normalized()
+
+        let key = ImageIdentity.normalizedPath(for: url)
+        if normalized.isEmpty {
+            records.removeValue(forKey: key)
+        } else {
+            records[key] = normalized
+        }
+        persist()
+    }
+
+    func move(from oldURL: URL, to newURL: URL) {
+        let oldKey = ImageIdentity.normalizedPath(for: oldURL)
+        let newKey = ImageIdentity.normalizedPath(for: newURL)
+        guard oldKey != newKey else { return }
+
+        if let metadata = records.removeValue(forKey: oldKey) {
+            records[newKey] = metadata
+            persist()
+        }
+    }
+
+    func remove(for url: URL) {
+        let key = ImageIdentity.normalizedPath(for: url)
+        guard records.removeValue(forKey: key) != nil else { return }
+        persist()
+    }
+
+    func remove(for urls: [URL]) {
+        var didChange = false
+        for url in urls {
+            let key = ImageIdentity.normalizedPath(for: url)
+            if records.removeValue(forKey: key) != nil {
+                didChange = true
+            }
+        }
+        if didChange {
+            persist()
+        }
+    }
+
+    // MARK: - Persistence
+
+    private func load() {
+        guard fileManager.fileExists(atPath: persistenceURL.path) else {
+            records = [:]
+            return
+        }
+
+        do {
+            let data = try Data(contentsOf: persistenceURL)
+            records = try JSONDecoder().decode([String: ImageMetadata].self, from: data)
+        } catch {
+            print("Error loading image metadata: \(error)")
+            records = [:]
+        }
+    }
+
+    private func persist() {
+        do {
+            let data = try JSONEncoder().encode(records)
+            try data.write(to: persistenceURL, options: .atomic)
+        } catch {
+            print("Error saving image metadata: \(error)")
+        }
+    }
+
+    // MARK: - Legacy Migration
+
+    private func migrateLegacyExtendedAttributes(from url: URL) -> ImageMetadata? {
+        var metadata = ImageMetadata.empty
+        var found = false
+
+        if let data = try? url.extendedAttribute(forName: "com.microfiche.tags"),
+           let string = String(data: data, encoding: .utf8) {
+            metadata.tags = string.components(separatedBy: ",").filter { !$0.isEmpty }
+            found = true
+        }
+        if let data = try? url.extendedAttribute(forName: "com.microfiche.labels"),
+           let string = String(data: data, encoding: .utf8) {
+            metadata.labels = string.components(separatedBy: ",").filter { !$0.isEmpty }
+            found = true
+        }
+        if let data = try? url.extendedAttribute(forName: "com.microfiche.comments"),
+           let string = String(data: data, encoding: .utf8) {
+            metadata.comments = string
+            found = true
+        }
+        if let data = try? url.extendedAttribute(forName: "com.microfiche.whereFrom"),
+           let string = String(data: data, encoding: .utf8) {
+            metadata.whereFrom = string
+            found = true
+        }
+
+        guard found else { return nil }
+        metadata.normalized()
+        return metadata.isEmpty ? nil : metadata
+    }
+}

--- a/Microfiche/Views/ImageDetailView.swift
+++ b/Microfiche/Views/ImageDetailView.swift
@@ -234,76 +234,28 @@ struct ImageMetadataInspectorView: View {
     }
 
     private func loadMetadata() {
-        tags = []
-        labels = []
-        comments = ""
-        whereFrom = ""
         isEditingTags = false
         isEditingLabels = false
         isEditingComments = false
         isEditingWhereFrom = false
 
-        var loadedFromFileSystem = false
-
-        if let data = try? file.url.extendedAttribute(forName: "com.microfiche.tags"),
-           let string = String(data: data, encoding: .utf8) {
-            tags = string.components(separatedBy: ",").filter { !$0.isEmpty }
-            loadedFromFileSystem = true
-        }
-        if let data = try? file.url.extendedAttribute(forName: "com.microfiche.labels"),
-           let string = String(data: data, encoding: .utf8) {
-            labels = string.components(separatedBy: ",").filter { !$0.isEmpty }
-            loadedFromFileSystem = true
-        }
-        if let data = try? file.url.extendedAttribute(forName: "com.microfiche.comments"),
-           let string = String(data: data, encoding: .utf8) {
-            comments = string
-            loadedFromFileSystem = true
-        }
-        if let data = try? file.url.extendedAttribute(forName: "com.microfiche.whereFrom"),
-           let string = String(data: data, encoding: .utf8) {
-            whereFrom = string
-            loadedFromFileSystem = true
-        }
-
-        if !loadedFromFileSystem {
-            loadFromUserDefaults()
-        }
+        let metadata = ImageMetadataStore.shared.metadata(for: file.url)
+        tags = metadata.tags
+        labels = metadata.labels
+        comments = metadata.comments
+        whereFrom = metadata.whereFrom
     }
 
     private func saveMetadata() {
-        guard FileManager.default.isWritableFile(atPath: file.url.path) else {
-            saveToUserDefaults()
-            return
-        }
-
-        do {
-            try file.url.setFinderComment(comments)
-            try file.url.setFinderTagsAndLabels(tags: tags, labels: labels)
-        } catch {
-            saveToUserDefaults()
-        }
-    }
-
-    private func saveToUserDefaults() {
-        let metadata: [String: Any] = [
-            "tags": tags,
-            "labels": labels,
-            "comments": comments,
-            "whereFrom": whereFrom
-        ]
-        UserDefaults.standard.set(metadata, forKey: "metadata_\(file.id.uuidString)")
-    }
-
-    private func loadFromUserDefaults() {
-        guard let metadata = UserDefaults.standard.dictionary(
-            forKey: "metadata_\(file.id.uuidString)"
-        ) else { return }
-
-        tags = metadata["tags"] as? [String] ?? []
-        labels = metadata["labels"] as? [String] ?? []
-        comments = metadata["comments"] as? String ?? ""
-        whereFrom = metadata["whereFrom"] as? String ?? ""
+        ImageMetadataStore.shared.save(
+            ImageMetadata(
+                tags: tags,
+                labels: labels,
+                comments: comments,
+                whereFrom: whereFrom
+            ),
+            for: file.url
+        )
     }
 }
 

--- a/MicroficheTests/MicroficheTests.swift
+++ b/MicroficheTests/MicroficheTests.swift
@@ -238,6 +238,102 @@ final class MicroficheTests: XCTestCase {
         XCTAssertEqual(reloadedStorage.getImages(for: sheet.id).count, 1)
     }
 
+    func testImageFileIdentityIsStableAcrossRescans() {
+        let url = URL(fileURLWithPath: "/Users/example/Pictures/sunset.jpg")
+        let first = ImageFile(url: url)
+        let second = ImageFile(url: url)
+
+        XCTAssertEqual(first.id, second.id)
+        XCTAssertEqual(first, second)
+        XCTAssertEqual(
+            first.id,
+            ImageIdentity.stableID(for: url.standardizedFileURL)
+        )
+    }
+
+    func testImageFileIdentityIgnoresRedundantPathComponents() {
+        let plain = ImageFile(url: URL(fileURLWithPath: "/Users/example/Pictures/photo.png"))
+        let withDot = ImageFile(
+            url: URL(fileURLWithPath: "/Users/example/Pictures/./photo.png")
+        )
+
+        XCTAssertEqual(plain.id, withDot.id)
+    }
+
+    @MainActor
+    func testImageMetadataStorePersistsAcrossReloads() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("microfiche-metadata-\(UUID().uuidString)", isDirectory: true)
+        let persistenceURL = root.appendingPathComponent("image-metadata.json")
+        let imageURL = URL(fileURLWithPath: "/Users/example/Pictures/catalog/frame-01.tif")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let store = ImageMetadataStore(persistenceURL: persistenceURL)
+        store.save(
+            ImageMetadata(
+                tags: ["keeper", "portrait"],
+                labels: ["Red"],
+                comments: "Looks good",
+                whereFrom: "Studio session"
+            ),
+            for: imageURL
+        )
+
+        let reloaded = ImageMetadataStore(persistenceURL: persistenceURL)
+        let metadata = reloaded.metadata(for: imageURL)
+        XCTAssertEqual(metadata.tags, ["keeper", "portrait"])
+        XCTAssertEqual(metadata.labels, ["Red"])
+        XCTAssertEqual(metadata.comments, "Looks good")
+        XCTAssertEqual(metadata.whereFrom, "Studio session")
+    }
+
+    @MainActor
+    func testImageMetadataStoreMovesRecordsOnRename() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("microfiche-metadata-move-\(UUID().uuidString)", isDirectory: true)
+        let persistenceURL = root.appendingPathComponent("image-metadata.json")
+        let oldURL = URL(fileURLWithPath: "/Users/example/Pictures/old-name.jpg")
+        let newURL = URL(fileURLWithPath: "/Users/example/Pictures/new-name.jpg")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let store = ImageMetadataStore(persistenceURL: persistenceURL)
+        store.save(
+            ImageMetadata(tags: ["archive"], labels: [], comments: "Keep", whereFrom: ""),
+            for: oldURL
+        )
+        store.move(from: oldURL, to: newURL)
+
+        XCTAssertTrue(store.metadata(for: oldURL).isEmpty)
+        XCTAssertEqual(store.metadata(for: newURL).tags, ["archive"])
+        XCTAssertEqual(store.metadata(for: newURL).comments, "Keep")
+    }
+
+    @MainActor
+    func testImageMetadataStoreRemovesEmptyRecords() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("microfiche-metadata-empty-\(UUID().uuidString)", isDirectory: true)
+        let persistenceURL = root.appendingPathComponent("image-metadata.json")
+        let imageURL = URL(fileURLWithPath: "/Users/example/Pictures/empty.jpg")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let store = ImageMetadataStore(persistenceURL: persistenceURL)
+        store.save(
+            ImageMetadata(tags: ["temp"], labels: [], comments: "", whereFrom: ""),
+            for: imageURL
+        )
+        store.save(.empty, for: imageURL)
+
+        let reloaded = ImageMetadataStore(persistenceURL: persistenceURL)
+        XCTAssertTrue(reloaded.metadata(for: imageURL).isEmpty)
+
+        let data = try Data(contentsOf: persistenceURL)
+        let decoded = try JSONDecoder().decode([String: ImageMetadata].self, from: data)
+        XCTAssertTrue(decoded.isEmpty)
+    }
+
     func testPerformanceExample() throws {
         // This is an example of a performance test case.
         self.measure {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Tags, labels, comments, and “Where From” notes now survive library rescans and app relaunches.

The inspector previously read `com.microfiche.*` xattrs / UUID-keyed UserDefaults, but saved Finder tags/comments (or UUID keys that changed every scan). This aligns identity and storage with the requirements for local metadata.

## Changes
- Derive stable `ImageFile` IDs from the normalized file path (SHA-256 → UUID)
- Add `ImageMetadataStore` persisting metadata to `Application Support/Microfiche/image-metadata.json`
- Wire the metadata inspector to that store
- Migrate metadata on rename; remove records when files are trashed
- One-time migration from any existing `com.microfiche.*` xattrs
- Unit tests for identity stability and store persistence/rename/empty cleanup

## Test plan
- [ ] Open an image, add tags/labels/comments/where-from, quit and relaunch — values should remain
- [ ] Switch folders and return — values should remain
- [ ] Rename a tagged file in-app — metadata should follow the new name
- [ ] Trash a tagged file — its metadata record should be removed from the store
- [ ] Run `MicroficheTests` (identity + metadata store cases)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f82de-1b10-7a64-bc6c-d0616c887ac6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f82de-1b10-7a64-bc6c-d0616c887ac6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

