### PR TITLE
Persist preview image cache to disk and fix cache invalidation

### DIFF
--- a/CACHING.md
+++ b/CACHING.md
@@ -14,13 +14,17 @@ Microfiche uses a multi-tier caching strategy to deliver instant image previews 
 
 **Implementation:**
 - Uses `NSCache<NSURL, NSImage>` for automatic memory management
-- Background processing queue with `.userInitiated` QoS for fast decoding
+- Persists optimized previews as PNG under `~/Library/Caches/MicrofichePreviews/`
+- Background processing queues (`.userInitiated` interactive / `.utility` prefetch)
 - Smart image optimization using `CGImageSource`
+- Disk entries keyed by stable SHA256 path digest (`ImageIdentity.cacheKey`)
+- Invalidates disk entries when the source file's modification date is newer
 
 **Cache Limits:**
-- **Count Limit:** 100 images maximum
+- **Count Limit:** 100 images maximum (in memory)
 - **Memory Limit:** 5 GB total
 - NSCache automatically evicts least-recently-used images when limits exceeded
+- Disk entries survive app relaunch until cleared or source files change
 
 **Optimization Strategy:**
 ```swift
@@ -30,12 +34,15 @@ Microfiche uses a multi-tier caching strategy to deliver instant image previews 
 ```
 
 **Key Methods:**
-- `getImage(for: URL)` - Instant cache lookup (synchronous)
-- `preloadImage(for: URL, completion:)` - Background loading and optimization
+- `getImage(for: URL)` - Instant memory lookup (synchronous)
+- `preloadImage(for: URL, completion:)` - Background load from disk or source
+- `clearCacheForFile(at:)` - Drop memory + disk entry for one file
+- `clearCache()` - Wipe memory and disk
 
 **Performance:**
-- Cache hit: <1ms (instant display)
-- Cache miss: 100-300ms (background loading with progress indicator)
+- Memory hit: <1ms (instant display)
+- Disk hit: typically much faster than re-decoding the source
+- Cold miss: 100-300ms (background loading with progress indicator)
 
 ---
 
@@ -46,12 +53,13 @@ Microfiche uses a multi-tier caching strategy to deliver instant image previews 
 **Location:** `Services/ImageCache.swift`
 
 **Implementation:**
-- Similar NSCache-based architecture
-- Generates size-specific thumbnails (e.g., 200px for grid, 40px for list)
-- Separate cache entries for different sizes
+- `NSCache` plus on-disk PNG files under `~/Library/Caches/MicroficheThumbnails/`
+- Size-specific thumbnails (e.g., 180px grid decode, 40px list)
+- Stable SHA256 path keys via `ImageIdentity.cacheKey` (survives relaunch)
+- Cleared per-file on rename/trash via `clearCacheForFile(at:)`
 
 **Cache Limits:**
-- Automatically managed by NSCache based on available memory
+- Count limit 300 / ~80 MB in memory; disk managed under Caches
 - Smaller memory footprint than PreviewImageCache (thumbnails only)
 
 ---
@@ -98,10 +106,12 @@ The entire library preloads as soon as you select a folder or contact sheet. Wit
 
 ## Storage Locations
 
-### Temporary Cache (In-Memory Only)
-- **PreviewImageCache:** NSCache in RAM (not persisted to disk)
-- **ImageCache:** NSCache in RAM (not persisted to disk)
-- **Benefit:** Automatic cleanup when app quits, no disk space consumed
+### Image Decode Caches (`~/Library/Caches/`)
+- **PreviewImageCache:** RAM (`NSCache`) + disk (`MicrofichePreviews/`)
+- **ImageCache:** RAM (`NSCache`) + disk (`MicroficheThumbnails/`)
+- **Keys:** Stable SHA256 of normalized path (not Swift's randomized `hash`)
+- **Invalidation:** Source modification date newer than cached file; also cleared on rename/trash and via **Clear Image Cache** (⌘⇧K)
+- **Benefit:** Fast cold starts without regenerating optimized previews/thumbnails
 
 ### Permanent Storage (Contact Sheets)
 - **Location:** `~/Library/Application Support/Microfiche/ContactSheets/`

--- a/Microfiche/ContentView.swift
+++ b/Microfiche/ContentView.swift
@@ -580,6 +580,10 @@ struct ContentView: View {
             }
         }
         ImageMetadataStore.shared.remove(for: trashedURLs)
+        for url in trashedURLs {
+            ImageCache.shared.clearCacheForFile(at: url)
+            PreviewImageCache.shared.clearCacheForFile(at: url)
+        }
 
         if let deletedDetailIndex {
             let nextIndex = min(deletedDetailIndex, imageFiles.count - 1)
@@ -717,6 +721,8 @@ struct ContentView: View {
         do {
             try FileManager.default.moveItem(at: oldURL, to: newURL)
             ImageMetadataStore.shared.move(from: oldURL, to: newURL)
+            ImageCache.shared.clearCacheForFile(at: oldURL)
+            PreviewImageCache.shared.clearCacheForFile(at: oldURL)
 
             if let index = imageFiles.firstIndex(where: { $0.url == oldURL }) {
                 let oldID = imageFiles[index].id

--- a/Microfiche/Extensions/NSImage+PNG.swift
+++ b/Microfiche/Extensions/NSImage+PNG.swift
@@ -1,0 +1,17 @@
+//
+//  NSImage+PNG.swift
+//  Microfiche
+//
+
+import AppKit
+
+extension NSImage {
+    var pngData: Data? {
+        guard let cgImage = cgImage(forProposedRect: nil, context: nil, hints: nil) else {
+            return nil
+        }
+
+        let representation = NSBitmapImageRep(cgImage: cgImage)
+        return representation.representation(using: .png, properties: [:])
+    }
+}

--- a/Microfiche/MicroficheApp.swift
+++ b/Microfiche/MicroficheApp.swift
@@ -32,9 +32,10 @@ struct MicroficheApp: App {
                 Divider()
                 Button("Clear Image Cache") {
                     ImageCache.shared.clearCache()
+                    PreviewImageCache.shared.clearCache()
                 }
                 .keyboardShortcut("k", modifiers: [.command, .shift])
-                
+
                 Button("Cache Info") {
                     showCacheInfo()
                 }
@@ -42,25 +43,25 @@ struct MicroficheApp: App {
             }
         }
     }
-    
+
     private func showCacheInfo() {
         let monitor = PerformanceMonitor.shared
         let hitRate = String(format: "%.1f%%", monitor.cacheHitRate * 100)
         let totalRequests = monitor.totalRequests
         let cacheHits = monitor.cacheHits
-        
+
         let alert = NSAlert()
         alert.messageText = "Cache Performance"
         alert.informativeText = """
         Cache Hit Rate: \(hitRate)
         Total Requests: \(totalRequests)
         Cache Hits: \(cacheHits)
-        
-        Image cache is stored in the app's cache directory and will be automatically managed. You can clear it manually if needed.
+
+        Thumbnails and optimized previews are stored in the app's cache directory and will be automatically managed. You can clear them manually if needed.
         """
         alert.addButton(withTitle: "OK")
         alert.addButton(withTitle: "Reset Stats")
-        
+
         let response = alert.runModal()
         if response == .alertSecondButtonReturn {
             monitor.reset()

--- a/Microfiche/Models/ImageIdentity.swift
+++ b/Microfiche/Models/ImageIdentity.swift
@@ -11,7 +11,7 @@ import Foundation
 enum ImageIdentity {
     /// Stable identity derived from the file's normalized path.
     static func stableID(for url: URL) -> UUID {
-        let digest = SHA256.hash(data: Data(normalizedPath(for: url).utf8))
+        let digest = pathDigest(for: url)
         let bytes = Array(digest.prefix(16))
         return UUID(uuid: (
             bytes[0], bytes[1], bytes[2], bytes[3],
@@ -21,8 +21,18 @@ enum ImageIdentity {
         ))
     }
 
+    /// Stable, process-independent key for on-disk image caches.
+    /// Prefer this over `String.hash`, which is randomized per launch.
+    static func cacheKey(for url: URL) -> String {
+        pathDigest(for: url).map { String(format: "%02x", $0) }.joined()
+    }
+
     /// Canonical path used for identity and local metadata keys.
     static func normalizedPath(for url: URL) -> String {
         url.standardizedFileURL.resolvingSymlinksInPath().path
+    }
+
+    private static func pathDigest(for url: URL) -> SHA256.Digest {
+        SHA256.hash(data: Data(normalizedPath(for: url).utf8))
     }
 }

--- a/Microfiche/Services/ImageCache.swift
+++ b/Microfiche/Services/ImageCache.swift
@@ -21,6 +21,7 @@ final class ImageCache {
     private let stateQueue = DispatchQueue(label: "com.microfiche.thumbnailcache.state")
     private let ioQueue = DispatchQueue(label: "com.microfiche.thumbnailcache.io", qos: .utility, attributes: .concurrent)
     private var inFlight: [String: [Completion]] = [:]
+    private var memoryKeysByPathKey: [String: Set<String>] = [:]
 
     private init() {
         let cachesDirectory = fileManager.urls(for: .cachesDirectory, in: .userDomainMask).first!
@@ -35,6 +36,7 @@ final class ImageCache {
         cache.removeAllObjects()
         stateQueue.sync {
             inFlight.removeAll()
+            memoryKeysByPathKey.removeAll()
         }
         try? fileManager.removeItem(at: cacheDirectory)
         try? fileManager.createDirectory(at: cacheDirectory, withIntermediateDirectories: true)
@@ -85,10 +87,22 @@ final class ImageCache {
     }
 
     func clearCacheForFile(at url: URL) {
-        let baseKey = String(url.path.hash)
+        let pathKey = ImageIdentity.cacheKey(for: url)
+
+        let memoryKeys = stateQueue.sync { () -> Set<String> in
+            let keys = memoryKeysByPathKey.removeValue(forKey: pathKey) ?? []
+            for key in keys {
+                inFlight.removeValue(forKey: key)
+            }
+            return keys
+        }
+
+        for key in memoryKeys {
+            cache.removeObject(forKey: key as NSString)
+        }
 
         if let contents = try? fileManager.contentsOfDirectory(at: cacheDirectory, includingPropertiesForKeys: nil) {
-            for file in contents where file.deletingPathExtension().lastPathComponent.hasPrefix(baseKey) {
+            for file in contents where file.deletingPathExtension().lastPathComponent.hasPrefix(pathKey) {
                 try? fileManager.removeItem(at: file)
             }
         }
@@ -96,7 +110,7 @@ final class ImageCache {
 
     private func loadImageFromDiskOrSource(for url: URL, size: CGFloat, key: String) -> NSImage? {
         if let diskImage = loadImageFromDisk(for: url, key: key) {
-            cache.setObject(diskImage, forKey: key as NSString, cost: cacheCost(for: diskImage))
+            storeInMemory(diskImage, for: url, key: key)
             return diskImage
         }
 
@@ -104,9 +118,20 @@ final class ImageCache {
             return nil
         }
 
-        cache.setObject(image, forKey: key as NSString, cost: cacheCost(for: image))
+        storeInMemory(image, for: url, key: key)
         persistImage(image, forKey: key)
         return image
+    }
+
+    private func storeInMemory(_ image: NSImage, for url: URL, key: String) {
+        cache.setObject(image, forKey: key as NSString, cost: cacheCost(for: image))
+
+        let pathKey = ImageIdentity.cacheKey(for: url)
+        stateQueue.sync {
+            var keys = memoryKeysByPathKey[pathKey] ?? []
+            keys.insert(key)
+            memoryKeysByPathKey[pathKey] = keys
+        }
     }
 
     private func loadImageFromDisk(for sourceURL: URL, key: String) -> NSImage? {
@@ -187,23 +212,12 @@ final class ImageCache {
     }
 
     private func cacheKey(for url: URL, size: CGFloat) -> String {
-        let pathHash = url.path.hash
+        let pathKey = ImageIdentity.cacheKey(for: url)
         let sizeString = String(format: "%.0f", size)
-        return "\(pathHash)_\(sizeString)"
+        return "\(pathKey)_\(sizeString)"
     }
 
     private func cacheCost(for image: NSImage) -> Int {
         Int(image.size.width * image.size.height * 4)
-    }
-}
-
-private extension NSImage {
-    var pngData: Data? {
-        guard let cgImage = cgImage(forProposedRect: nil, context: nil, hints: nil) else {
-            return nil
-        }
-
-        let representation = NSBitmapImageRep(cgImage: cgImage)
-        return representation.representation(using: .png, properties: [:])
     }
 }

--- a/Microfiche/Services/PreviewImageCache.swift
+++ b/Microfiche/Services/PreviewImageCache.swift
@@ -15,12 +15,19 @@ final class PreviewImageCache {
     typealias Completion = (NSImage?) -> Void
 
     private let cache = NSCache<NSURL, NSImage>()
+    private let fileManager = FileManager.default
+    private let cacheDirectory: URL
     private let interactiveQueue = DispatchQueue(label: "com.microfiche.previewcache.interactive", qos: .userInitiated, attributes: .concurrent)
     private let prefetchQueue = DispatchQueue(label: "com.microfiche.previewcache.prefetch", qos: .utility, attributes: .concurrent)
     private let stateQueue = DispatchQueue(label: "com.microfiche.previewcache.state")
+    private let ioQueue = DispatchQueue(label: "com.microfiche.previewcache.io", qos: .utility, attributes: .concurrent)
     private var inFlight: [String: [Completion]] = [:]
 
     private init() {
+        let cachesDirectory = fileManager.urls(for: .cachesDirectory, in: .userDomainMask).first!
+        cacheDirectory = cachesDirectory.appendingPathComponent("MicrofichePreviews")
+        try? fileManager.createDirectory(at: cacheDirectory, withIntermediateDirectories: true)
+
         cache.countLimit = 100
         cache.totalCostLimit = 5 * 1024 * 1024 * 1024
     }
@@ -43,7 +50,7 @@ final class PreviewImageCache {
             return
         }
 
-        let key = url.path
+        let key = ImageIdentity.cacheKey(for: url)
 
         stateQueue.async {
             if self.inFlight[key] != nil {
@@ -58,12 +65,7 @@ final class PreviewImageCache {
             let queue = self.queue(for: priority)
             queue.async {
                 let image = autoreleasepool {
-                    self.loadAndOptimizeImage(from: url)
-                }
-
-                if let image = image {
-                    let cost = Int(image.size.width * image.size.height * 4)
-                    self.cache.setObject(image, forKey: url as NSURL, cost: cost)
+                    self.loadImageFromDiskOrSource(for: url, key: key)
                 }
 
                 let completions = self.stateQueue.sync {
@@ -80,6 +82,42 @@ final class PreviewImageCache {
         }
     }
 
+    func clearCache() {
+        cache.removeAllObjects()
+        stateQueue.sync {
+            inFlight.removeAll()
+        }
+        try? fileManager.removeItem(at: cacheDirectory)
+        try? fileManager.createDirectory(at: cacheDirectory, withIntermediateDirectories: true)
+    }
+
+    func clearCacheForFile(at url: URL) {
+        cache.removeObject(forKey: url as NSURL)
+
+        let key = ImageIdentity.cacheKey(for: url)
+        stateQueue.sync {
+            inFlight.removeValue(forKey: key)
+        }
+
+        let cacheURL = cacheURL(forKey: key)
+        try? fileManager.removeItem(at: cacheURL)
+    }
+
+    func preloadLibrary(urls: [URL], priority: DispatchQoS.QoSClass = .background) {
+        let imageURLs = urls.filter { url in
+            let ext = url.pathExtension.lowercased()
+            return ext != "pdf" && ext != "svg"
+        }
+
+        for url in imageURLs {
+            if cache.object(forKey: url as NSURL) != nil {
+                continue
+            }
+
+            preloadImage(for: url, priority: priority)
+        }
+    }
+
     private func queue(for priority: DispatchQoS.QoSClass) -> DispatchQueue {
         switch priority {
         case .userInteractive, .userInitiated:
@@ -87,6 +125,40 @@ final class PreviewImageCache {
         default:
             return prefetchQueue
         }
+    }
+
+    private func loadImageFromDiskOrSource(for url: URL, key: String) -> NSImage? {
+        if let diskImage = loadImageFromDisk(for: url, key: key) {
+            cache.setObject(diskImage, forKey: url as NSURL, cost: cacheCost(for: diskImage))
+            return diskImage
+        }
+
+        guard let image = loadAndOptimizeImage(from: url) else {
+            return nil
+        }
+
+        cache.setObject(image, forKey: url as NSURL, cost: cacheCost(for: image))
+        persistImage(image, forKey: key)
+        return image
+    }
+
+    private func loadImageFromDisk(for sourceURL: URL, key: String) -> NSImage? {
+        let cacheURL = cacheURL(forKey: key)
+
+        guard fileManager.fileExists(atPath: cacheURL.path) else {
+            return nil
+        }
+
+        if let cacheAttributes = try? fileManager.attributesOfItem(atPath: cacheURL.path),
+           let sourceAttributes = try? fileManager.attributesOfItem(atPath: sourceURL.path),
+           let cacheModDate = cacheAttributes[.modificationDate] as? Date,
+           let sourceModDate = sourceAttributes[.modificationDate] as? Date,
+           sourceModDate > cacheModDate {
+            try? fileManager.removeItem(at: cacheURL)
+            return nil
+        }
+
+        return NSImage(contentsOf: cacheURL)
     }
 
     private func loadAndOptimizeImage(from url: URL) -> NSImage? {
@@ -119,25 +191,22 @@ final class PreviewImageCache {
         return NSImage(cgImage: cgImage, size: NSSize(width: targetWidth, height: targetHeight))
     }
 
-    func clearCache() {
-        cache.removeAllObjects()
-        stateQueue.sync {
-            inFlight.removeAll()
+    private func persistImage(_ image: NSImage, forKey key: String) {
+        let cacheURL = cacheURL(forKey: key)
+
+        ioQueue.async {
+            guard let data = image.pngData else { return }
+            try? data.write(to: cacheURL, options: .atomic)
         }
     }
 
-    func preloadLibrary(urls: [URL], priority: DispatchQoS.QoSClass = .background) {
-        let imageURLs = urls.filter { url in
-            let ext = url.pathExtension.lowercased()
-            return ext != "pdf" && ext != "svg"
-        }
+    private func cacheURL(forKey key: String) -> URL {
+        cacheDirectory
+            .appendingPathComponent(key)
+            .appendingPathExtension("png")
+    }
 
-        for url in imageURLs {
-            if cache.object(forKey: url as NSURL) != nil {
-                continue
-            }
-
-            preloadImage(for: url, priority: priority)
-        }
+    private func cacheCost(for image: NSImage) -> Int {
+        Int(image.size.width * image.size.height * 4)
     }
 }

--- a/MicroficheTests/MicroficheTests.swift
+++ b/MicroficheTests/MicroficheTests.swift
@@ -52,6 +52,87 @@ final class MicroficheTests: XCTestCase {
         wait(for: [expectation], timeout: 3.0)
     }
 
+    func testImageIdentityCacheKeyIsStableAndPathNormalized() {
+        let plain = URL(fileURLWithPath: "/Users/example/Pictures/photo.png")
+        let withDot = URL(fileURLWithPath: "/Users/example/Pictures/./photo.png")
+
+        let first = ImageIdentity.cacheKey(for: plain)
+        let second = ImageIdentity.cacheKey(for: plain)
+        let normalized = ImageIdentity.cacheKey(for: withDot)
+
+        XCTAssertEqual(first, second)
+        XCTAssertEqual(first, normalized)
+        XCTAssertEqual(first.count, 64)
+        XCTAssertTrue(first.allSatisfy(\.isHexDigit))
+    }
+
+    func testPreviewImageCachePersistsToDiskAndClearsPerFile() throws {
+        let pngData = Data(base64Encoded:
+            "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="
+        )!
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("microfiche-preview-cache-\(UUID().uuidString).png")
+        try pngData.write(to: url)
+        defer {
+            try? FileManager.default.removeItem(at: url)
+            PreviewImageCache.shared.clearCacheForFile(at: url)
+        }
+
+        PreviewImageCache.shared.clearCacheForFile(at: url)
+
+        let loadExpectation = expectation(description: "preview load completes")
+        PreviewImageCache.shared.preloadImage(for: url) { image in
+            XCTAssertNotNil(image)
+            XCTAssertNotNil(PreviewImageCache.shared.getImage(for: url))
+            loadExpectation.fulfill()
+        }
+        wait(for: [loadExpectation], timeout: 3.0)
+
+        let cachesDirectory = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!
+        let diskURL = cachesDirectory
+            .appendingPathComponent("MicrofichePreviews")
+            .appendingPathComponent(ImageIdentity.cacheKey(for: url))
+            .appendingPathExtension("png")
+
+        var diskReady = false
+        let deadline = Date().addingTimeInterval(3)
+        while Date() < deadline {
+            if FileManager.default.fileExists(atPath: diskURL.path) {
+                diskReady = true
+                break
+            }
+            Thread.sleep(forTimeInterval: 0.05)
+        }
+        XCTAssertTrue(diskReady, "Expected optimized preview PNG on disk")
+
+        PreviewImageCache.shared.clearCacheForFile(at: url)
+        XCTAssertNil(PreviewImageCache.shared.getImage(for: url))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: diskURL.path))
+    }
+
+    func testImageCacheClearCacheForFileRemovesMemoryEntry() throws {
+        let pngData = Data(base64Encoded:
+            "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="
+        )!
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("microfiche-thumb-clear-\(UUID().uuidString).png")
+        try pngData.write(to: url)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        ImageCache.shared.clearCache()
+
+        let expectation = expectation(description: "thumbnail load completes")
+        ImageCache.shared.loadImage(for: url, size: 40) { image in
+            XCTAssertNotNil(image)
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 3.0)
+        XCTAssertNotNil(ImageCache.shared.getImage(for: url, size: 40))
+
+        ImageCache.shared.clearCacheForFile(at: url)
+        XCTAssertNil(ImageCache.shared.getImage(for: url, size: 40))
+    }
+
     func testGridColumnCountUsesAvailableWidthAndHandlesZeroWidth() {
         XCTAssertEqual(
             ImageGridView.Layout.columnCount(availableWidth: 900, thumbnailWidth: 120),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Improves local image caching without adding new thumbnail generation paths.

- **Disk-backed `PreviewImageCache`**: optimized ~2000px previews now persist under `~/Library/Caches/MicrofichePreviews/` with source mtime invalidation (same pattern as thumbnails).
- **Stable cache keys**: both preview and thumbnail caches use `ImageIdentity.cacheKey` (SHA256 of normalized path) instead of Swift’s randomized `String.hash`, so disk entries survive app relaunch.
- **Lifecycle invalidation**: rename and trash clear both `ImageCache` and `PreviewImageCache` for the affected file (memory + disk).
- **Clear Image Cache (⌘⇧K)** now clears thumbnails and previews.
- Docs (`CACHING.md`) and unit tests updated for the new behavior.

## Test plan
- [ ] Open a folder, preview images, quit and relaunch — previews should appear without re-decoding from source when disk cache is warm.
- [ ] Rename an image — old cache entries are dropped; preview/thumbnail regenerate for the new path.
- [ ] Trash an image — no stale cache left for that path.
- [ ] ⌘⇧K clears both thumbnail and preview caches.
- [ ] Unit tests covering stable keys, preview disk persistence, and per-file clear.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f9eff-5ec4-7580-a18e-2173e2e014cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f9eff-5ec4-7580-a18e-2173e2e014cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

