### PR TITLE
Native Finder metadata editing in the detail inspector

### DIFF
--- a/Microfiche/ContentView.swift
+++ b/Microfiche/ContentView.swift
@@ -533,7 +533,8 @@ struct ContentView: View {
             focusedImageFileID = fileID
             withAnimation(MicroficheMotion.transition) {
                 detailViewFile = file
-                isMetadataInspectorPresented = false
+                // Keep the metadata inspector available for editing Finder labels/tags.
+                isMetadataInspectorPresented = true
             }
         }
     }
@@ -541,7 +542,6 @@ struct ContentView: View {
     private func closeImageDetail() {
         withAnimation(MicroficheMotion.transition) {
             detailViewFile = nil
-            isMetadataInspectorPresented = true
         }
         requestScrollToFocusedImage()
     }

--- a/Microfiche/Models/FinderLabel.swift
+++ b/Microfiche/Models/FinderLabel.swift
@@ -1,0 +1,75 @@
+//
+//  FinderLabel.swift
+//  Microfiche
+//
+//  Finder color labels (NSURL.labelNumberKey values 0–7).
+//
+
+import SwiftUI
+
+enum FinderLabel: Int, CaseIterable, Codable, Sendable, Identifiable {
+    case none = 0
+    case gray = 1
+    case green = 2
+    case purple = 3
+    case blue = 4
+    case yellow = 5
+    case orange = 6
+    case red = 7
+
+    var id: Int { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .none: "None"
+        case .gray: "Gray"
+        case .green: "Green"
+        case .purple: "Purple"
+        case .blue: "Blue"
+        case .yellow: "Yellow"
+        case .orange: "Orange"
+        case .red: "Red"
+        }
+    }
+
+    /// Finder-accurate swatch colors for the label picker.
+    var swatchColor: Color? {
+        switch self {
+        case .none: nil
+        case .gray: Color(red: 0.65, green: 0.65, blue: 0.67)
+        case .green: Color(red: 0.30, green: 0.85, blue: 0.39)
+        case .purple: Color(red: 0.69, green: 0.32, blue: 0.87)
+        case .blue: Color(red: 0.20, green: 0.48, blue: 0.96)
+        case .yellow: Color(red: 1.00, green: 0.80, blue: 0.00)
+        case .orange: Color(red: 1.00, green: 0.58, blue: 0.00)
+        case .red: Color(red: 1.00, green: 0.23, blue: 0.19)
+        }
+    }
+
+    /// Colored labels in Finder’s usual left-to-right order (excluding None).
+    static var coloredCases: [FinderLabel] {
+        [.gray, .green, .purple, .blue, .yellow, .orange, .red]
+    }
+
+    /// Map legacy Microfiche free-text labels (e.g. "Red") onto a Finder color.
+    static func migrating(from legacyLabels: [String]) -> FinderLabel? {
+        for raw in legacyLabels {
+            let name = raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+            guard !name.isEmpty else { continue }
+            if let match = FinderLabel.allCases.first(where: {
+                $0 != .none && $0.displayName.lowercased() == name
+            }) {
+                return match
+            }
+        }
+        return nil
+    }
+
+    init(labelNumber: Int?) {
+        if let labelNumber, let label = FinderLabel(rawValue: labelNumber) {
+            self = label
+        } else {
+            self = .none
+        }
+    }
+}

--- a/Microfiche/Models/ImageMetadata.swift
+++ b/Microfiche/Models/ImageMetadata.swift
@@ -3,12 +3,14 @@
 //  Microfiche
 //
 //  Locally stored organization metadata for a library image.
+//  `labels` is legacy free-text (migrated to Finder color labels).
 //
 
 import Foundation
 
 struct ImageMetadata: Codable, Equatable, Sendable {
     var tags: [String]
+    /// Legacy free-text labels. Prefer FinderLabel / NativeFileMetadataService.
     var labels: [String]
     var comments: String
     var whereFrom: String

--- a/Microfiche/Services/ImageMetadataStore.swift
+++ b/Microfiche/Services/ImageMetadataStore.swift
@@ -2,8 +2,10 @@
 //  ImageMetadataStore.swift
 //  Microfiche
 //
-//  Local JSON persistence for tags, labels, comments, and source notes.
-//  Metadata is stored in Application Support (not written into image files).
+//  Local JSON persistence for tags, comments, and source notes.
+//  Finder color labels, tags, and comments are also written natively via
+//  NativeFileMetadataService; this store mirrors tags/comments and keeps
+//  Microfiche-only fields (whereFrom). Legacy free-text `labels` are migrated.
 //
 
 import Foundation

--- a/Microfiche/Services/NativeFileMetadataService.swift
+++ b/Microfiche/Services/NativeFileMetadataService.swift
@@ -1,0 +1,124 @@
+//
+//  NativeFileMetadataService.swift
+//  Microfiche
+//
+//  Read/write Finder-native file metadata (color labels, tags, comments).
+//
+
+import Foundation
+
+struct NativeFileMetadata: Equatable, Sendable {
+    var label: FinderLabel
+    var tagNames: [String]
+    var comment: String
+
+    static let empty = NativeFileMetadata(label: .none, tagNames: [], comment: "")
+}
+
+enum NativeFileMetadataService {
+    private static let finderCommentAttribute = "com.apple.metadata:kMDItemFinderComment"
+    private static let finderInfoAttribute = "com.apple.FinderInfo"
+
+    static func load(from url: URL) -> NativeFileMetadata {
+        var label = FinderLabel.none
+        var tagNames: [String] = []
+
+        if let values = try? url.resourceValues(forKeys: [.labelNumberKey, .tagNamesKey]) {
+            label = FinderLabel(labelNumber: values.labelNumber)
+            tagNames = Self.normalizeList(values.tagNames ?? [])
+        } else if let finderLabel = readLabelFromFinderInfo(at: url) {
+            label = finderLabel
+        }
+
+        let comment = (try? readFinderComment(from: url)) ?? ""
+        return NativeFileMetadata(label: label, tagNames: tagNames, comment: comment)
+    }
+
+    static func save(_ metadata: NativeFileMetadata, for url: URL) throws {
+        try setLabel(metadata.label, for: url)
+        try setTagNames(metadata.tagNames, for: url)
+        try setComment(metadata.comment, for: url)
+    }
+
+    static func setLabel(_ label: FinderLabel, for url: URL) throws {
+        var mutableURL = url
+        var values = URLResourceValues()
+        values.labelNumber = label.rawValue
+        do {
+            try mutableURL.setResourceValues(values)
+        } catch {
+            try writeLabelToFinderInfo(label, at: url)
+        }
+    }
+
+    static func setTagNames(_ tagNames: [String], for url: URL) throws {
+        var mutableURL = url
+        var values = URLResourceValues()
+        values.tagNames = normalizeList(tagNames)
+        try mutableURL.setResourceValues(values)
+    }
+
+    static func setComment(_ comment: String, for url: URL) throws {
+        let trimmed = comment.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.isEmpty {
+            try? url.removeExtendedAttribute(forName: finderCommentAttribute)
+            return
+        }
+
+        let data = try PropertyListSerialization.data(
+            fromPropertyList: trimmed,
+            format: .binary,
+            options: 0
+        )
+        try url.setExtendedAttribute(data, forName: finderCommentAttribute)
+    }
+
+    // MARK: - Helpers
+
+    private static func normalizeList(_ values: [String]) -> [String] {
+        var seen = Set<String>()
+        var result: [String] = []
+        for value in values {
+            let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty, !seen.contains(trimmed) else { continue }
+            seen.insert(trimmed)
+            result.append(trimmed)
+        }
+        return result
+    }
+
+    private static func readFinderComment(from url: URL) throws -> String {
+        let data = try url.extendedAttribute(forName: finderCommentAttribute)
+        let object = try PropertyListSerialization.propertyList(from: data, options: [], format: nil)
+        if let string = object as? String {
+            return string.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+        if let strings = object as? [String] {
+            return strings.joined(separator: "\n").trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+        return ""
+    }
+
+    /// Fallback for volumes that reject `labelNumber` resource values.
+    private static func readLabelFromFinderInfo(at url: URL) -> FinderLabel? {
+        guard let data = try? url.extendedAttribute(forName: finderInfoAttribute),
+              data.count >= 10 else {
+            return nil
+        }
+        let flags = data[9]
+        let labelBits = Int((flags >> 1) & 0x07)
+        return FinderLabel(rawValue: labelBits)
+    }
+
+    private static func writeLabelToFinderInfo(_ label: FinderLabel, at url: URL) throws {
+        var data = (try? url.extendedAttribute(forName: finderInfoAttribute)) ?? Data(count: 32)
+        if data.count < 32 {
+            data.append(contentsOf: [UInt8](repeating: 0, count: 32 - data.count))
+        }
+
+        var flags = data[9]
+        flags = (flags & 0xF1) | (UInt8(label.rawValue << 1) & 0x0E)
+        data[9] = flags
+        try url.setExtendedAttribute(data, forName: finderInfoAttribute)
+    }
+}

--- a/Microfiche/Views/ImageDetailView.swift
+++ b/Microfiche/Views/ImageDetailView.swift
@@ -5,6 +5,7 @@
 //  Focused image canvas and the persistent library metadata inspector.
 //
 
+import AppKit
 import PDFKit
 import SwiftUI
 
@@ -68,7 +69,15 @@ struct ImageDetailView: View {
                     Image(systemName: "square.and.arrow.up")
                 }
 
-                Button(action: {}) {
+                Menu {
+                    Button("Reveal in Finder") {
+                        NSWorkspace.shared.activateFileViewerSelecting([file.url])
+                    }
+                    Button("Copy Path") {
+                        NSPasteboard.general.clearContents()
+                        NSPasteboard.general.setString(file.url.path, forType: .string)
+                    }
+                } label: {
                     Image(systemName: "ellipsis")
                 }
                 .help("More")
@@ -103,27 +112,34 @@ struct ImageDetailView: View {
         }
     }
 }
+
 // MARK: - Metadata Inspector
 
 struct ImageMetadataInspectorView: View {
     let file: ImageFile
 
+    @State private var finderLabel: FinderLabel = .none
     @State private var tags: [String] = []
-    @State private var labels: [String] = []
     @State private var comments = ""
     @State private var whereFrom = ""
     @State private var isEditingTags = false
-    @State private var isEditingLabels = false
     @State private var isEditingComments = false
     @State private var isEditingWhereFrom = false
     @State private var newTag = ""
-    @State private var newLabel = ""
+    @State private var saveError: String?
 
     var body: some View {
         ScrollView {
-            VStack(alignment: .leading, spacing: 24) {
+            VStack(alignment: .leading, spacing: 22) {
+                headerSection
+
+                FinderLabelPicker(selection: finderLabel) { label in
+                    applyFinderLabel(label)
+                }
+
                 EditableChipSection(
                     title: "Tags",
+                    subtitle: "Finder tags",
                     itemName: "tag",
                     items: $tags,
                     isEditing: $isEditingTags,
@@ -132,18 +148,9 @@ struct ImageMetadataInspectorView: View {
                     onSave: saveMetadata
                 )
 
-                EditableChipSection(
-                    title: "Labels",
-                    itemName: "label",
-                    items: $labels,
-                    isEditing: $isEditingLabels,
-                    newItem: $newLabel,
-                    chipColor: Color.orange.opacity(0.16),
-                    onSave: saveMetadata
-                )
-
                 editableTextSection(
                     title: "Comments",
+                    subtitle: "Finder comments",
                     placeholder: "No comments",
                     text: $comments,
                     isEditing: $isEditingComments,
@@ -152,31 +159,20 @@ struct ImageMetadataInspectorView: View {
 
                 editableTextSection(
                     title: "Where From",
+                    subtitle: "Stored in Microfiche",
                     placeholder: "No source specified",
                     text: $whereFrom,
                     isEditing: $isEditingWhereFrom,
                     isMultiline: false
                 )
 
-                VStack(alignment: .leading, spacing: 10) {
-                    Text("File Info")
-                        .font(.headline)
+                fileInfoSection
 
-                    VStack(alignment: .leading, spacing: 6) {
-                        InfoRow(label: "Name", value: file.name)
-                        InfoRow(label: "Path", value: file.url.path)
-                        InfoRow(label: "Type", value: file.url.pathExtension.uppercased())
-
-                        if let fileSize = file.url.formattedFileSize() {
-                            InfoRow(label: "Size", value: fileSize)
-                        }
-                        if let creationDate = file.url.formattedCreationDate() {
-                            InfoRow(label: "Created", value: creationDate)
-                        }
-                        if let modificationDate = file.url.formattedModificationDate() {
-                            InfoRow(label: "Modified", value: modificationDate)
-                        }
-                    }
+                if let saveError {
+                    Text(saveError)
+                        .font(.caption)
+                        .foregroundStyle(.red)
+                        .textSelection(.enabled)
                 }
             }
             .padding(20)
@@ -189,18 +185,62 @@ struct ImageMetadataInspectorView: View {
         }
     }
 
+    private var headerSection: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(file.name)
+                .font(.system(size: 15, weight: .semibold))
+                .lineLimit(2)
+                .textSelection(.enabled)
+
+            Text(file.url.deletingLastPathComponent().path)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .lineLimit(2)
+                .textSelection(.enabled)
+        }
+    }
+
+    private var fileInfoSection: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("File Info")
+                .font(.headline)
+
+            VStack(alignment: .leading, spacing: 6) {
+                InfoRow(label: "Type", value: file.url.pathExtension.uppercased())
+
+                if let fileSize = file.url.formattedFileSize() {
+                    InfoRow(label: "Size", value: fileSize)
+                }
+                if let creationDate = file.url.formattedCreationDate() {
+                    InfoRow(label: "Created", value: creationDate)
+                }
+                if let modificationDate = file.url.formattedModificationDate() {
+                    InfoRow(label: "Modified", value: modificationDate)
+                }
+            }
+        }
+    }
+
     @ViewBuilder
     private func editableTextSection(
         title: String,
+        subtitle: String? = nil,
         placeholder: String,
         text: Binding<String>,
         isEditing: Binding<Bool>,
         isMultiline: Bool
     ) -> some View {
         VStack(alignment: .leading, spacing: 8) {
-            HStack {
-                Text(title)
-                    .font(.headline)
+            HStack(alignment: .firstTextBaseline) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(title)
+                        .font(.headline)
+                    if let subtitle {
+                        Text(subtitle)
+                            .font(.caption)
+                            .foregroundStyle(.tertiary)
+                    }
+                }
                 Spacer()
                 Button {
                     isEditing.wrappedValue.toggle()
@@ -209,6 +249,7 @@ struct ImageMetadataInspectorView: View {
                     Image(systemName: isEditing.wrappedValue ? "checkmark" : "pencil")
                 }
                 .buttonStyle(.borderless)
+                .help(isEditing.wrappedValue ? "Done" : "Edit \(title)")
             }
 
             if isEditing.wrappedValue {
@@ -235,22 +276,63 @@ struct ImageMetadataInspectorView: View {
 
     private func loadMetadata() {
         isEditingTags = false
-        isEditingLabels = false
         isEditingComments = false
         isEditingWhereFrom = false
+        newTag = ""
+        saveError = nil
 
-        let metadata = ImageMetadataStore.shared.metadata(for: file.url)
-        tags = metadata.tags
-        labels = metadata.labels
-        comments = metadata.comments
-        whereFrom = metadata.whereFrom
+        let local = ImageMetadataStore.shared.metadata(for: file.url)
+        let native = NativeFileMetadataService.load(from: file.url)
+
+        finderLabel = native.label
+        tags = native.tagNames.isEmpty ? local.tags : native.tagNames
+        comments = native.comment.isEmpty ? local.comments : native.comment
+        whereFrom = local.whereFrom
+
+        if native.label == .none,
+           let migrated = FinderLabel.migrating(from: local.labels) {
+            applyFinderLabel(migrated)
+        } else if !local.labels.isEmpty {
+            // Drop obsolete free-text labels once native labels own this field.
+            persistLocalMetadata()
+        }
+    }
+
+    private func applyFinderLabel(_ label: FinderLabel) {
+        finderLabel = label
+        do {
+            try NativeFileMetadataService.setLabel(label, for: file.url)
+            persistLocalMetadata()
+            saveError = nil
+        } catch {
+            saveError = "Couldn’t update Finder label: \(error.localizedDescription)"
+        }
     }
 
     private func saveMetadata() {
+        do {
+            try NativeFileMetadataService.save(
+                NativeFileMetadata(
+                    label: finderLabel,
+                    tagNames: tags,
+                    comment: comments
+                ),
+                for: file.url
+            )
+            persistLocalMetadata()
+            saveError = nil
+        } catch {
+            // Keep a local copy even when the file system rejects native writes.
+            persistLocalMetadata()
+            saveError = "Couldn’t write Finder metadata: \(error.localizedDescription)"
+        }
+    }
+
+    private func persistLocalMetadata() {
         ImageMetadataStore.shared.save(
             ImageMetadata(
                 tags: tags,
-                labels: labels,
+                labels: [],
                 comments: comments,
                 whereFrom: whereFrom
             ),
@@ -259,10 +341,84 @@ struct ImageMetadataInspectorView: View {
     }
 }
 
+// MARK: - Finder Label Picker
+
+struct FinderLabelPicker: View {
+    let selection: FinderLabel
+    let onSelect: (FinderLabel) -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Label")
+                    .font(.headline)
+                Text("Finder color label")
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
+            }
+
+            HStack(spacing: 10) {
+                labelDot(for: .none)
+
+                ForEach(FinderLabel.coloredCases) { label in
+                    labelDot(for: label)
+                }
+            }
+            .accessibilityElement(children: .contain)
+            .accessibilityLabel("Finder label")
+
+            Text(selection == .none ? "No label" : selection.displayName)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private func labelDot(for label: FinderLabel) -> some View {
+        let isSelected = selection == label
+
+        return Button {
+            onSelect(label)
+        } label: {
+            ZStack {
+                if label == .none {
+                    Circle()
+                        .strokeBorder(Color(NSColor.tertiaryLabelColor), lineWidth: 1.5)
+                        .background(Circle().fill(Color(NSColor.controlBackgroundColor)))
+                        .overlay {
+                            Image(systemName: "nosign")
+                                .font(.system(size: 9, weight: .semibold))
+                                .foregroundStyle(.secondary)
+                        }
+                } else if let color = label.swatchColor {
+                    Circle()
+                        .fill(color)
+                        .overlay {
+                            Circle()
+                                .strokeBorder(Color.black.opacity(0.12), lineWidth: 0.5)
+                        }
+                }
+            }
+            .frame(width: 22, height: 22)
+            .padding(3)
+            .overlay {
+                if isSelected {
+                    Circle()
+                        .strokeBorder(Color.primary.opacity(0.85), lineWidth: 2)
+                }
+            }
+        }
+        .buttonStyle(.plain)
+        .help(label.displayName)
+        .accessibilityLabel(label.displayName)
+        .accessibilityAddTraits(isSelected ? .isSelected : [])
+    }
+}
+
 // MARK: - Shared Inspector Components
 
 struct EditableChipSection: View {
     let title: String
+    var subtitle: String? = nil
     let itemName: String
     @Binding var items: [String]
     @Binding var isEditing: Bool
@@ -272,9 +428,16 @@ struct EditableChipSection: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
-            HStack {
-                Text(title)
-                    .font(.headline)
+            HStack(alignment: .firstTextBaseline) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(title)
+                        .font(.headline)
+                    if let subtitle {
+                        Text(subtitle)
+                            .font(.caption)
+                            .foregroundStyle(.tertiary)
+                    }
+                }
                 Spacer()
                 Button {
                     isEditing.toggle()
@@ -283,21 +446,16 @@ struct EditableChipSection: View {
                     Image(systemName: isEditing ? "checkmark" : "plus")
                 }
                 .buttonStyle(.borderless)
+                .help(isEditing ? "Done" : "Add \(itemName)")
             }
 
             if isEditing {
                 HStack {
                     TextField("Add \(itemName)", text: $newItem)
                         .textFieldStyle(.roundedBorder)
-                    Button("Add") {
-                        let value = newItem.trimmingCharacters(in: .whitespacesAndNewlines)
-                        if !value.isEmpty && !items.contains(value) {
-                            items.append(value)
-                            newItem = ""
-                            onSave()
-                        }
-                    }
-                    .buttonStyle(.borderless)
+                        .onSubmit(addItem)
+                    Button("Add", action: addItem)
+                        .buttonStyle(.borderless)
                 }
             }
 
@@ -330,6 +488,14 @@ struct EditableChipSection: View {
                 }
             }
         }
+    }
+
+    private func addItem() {
+        let value = newItem.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !value.isEmpty, !items.contains(value) else { return }
+        items.append(value)
+        newItem = ""
+        onSave()
     }
 }
 

--- a/MicroficheTests/MicroficheTests.swift
+++ b/MicroficheTests/MicroficheTests.swift
@@ -415,6 +415,44 @@ final class MicroficheTests: XCTestCase {
         XCTAssertTrue(decoded.isEmpty)
     }
 
+    func testFinderLabelMigratesLegacyColorNames() {
+        XCTAssertEqual(FinderLabel.migrating(from: ["Red"]), .red)
+        XCTAssertEqual(FinderLabel.migrating(from: ["  orange "]), .orange)
+        XCTAssertEqual(FinderLabel.migrating(from: ["favorite", "Blue"]), .blue)
+        XCTAssertNil(FinderLabel.migrating(from: ["favorite", "keeper"]))
+        XCTAssertEqual(FinderLabel(labelNumber: 7), .red)
+        XCTAssertEqual(FinderLabel(labelNumber: nil), .none)
+    }
+
+    func testNativeFileMetadataRoundTripsLabelTagsAndComment() throws {
+        let fileManager = FileManager.default
+        let url = fileManager.temporaryDirectory
+            .appendingPathComponent("microfiche-native-meta-\(UUID().uuidString).txt")
+        try "sample".write(to: url, atomically: true, encoding: .utf8)
+        defer { try? fileManager.removeItem(at: url) }
+
+        let expected = NativeFileMetadata(
+            label: .orange,
+            tagNames: ["keeper", "portrait"],
+            comment: "Looks good"
+        )
+        try NativeFileMetadataService.save(expected, for: url)
+
+        let loaded = NativeFileMetadataService.load(from: url)
+        XCTAssertEqual(loaded.label, .orange)
+        XCTAssertEqual(loaded.tagNames, ["keeper", "portrait"])
+        XCTAssertEqual(loaded.comment, "Looks good")
+
+        try NativeFileMetadataService.setLabel(.none, for: url)
+        try NativeFileMetadataService.setTagNames([], for: url)
+        try NativeFileMetadataService.setComment("", for: url)
+
+        let cleared = NativeFileMetadataService.load(from: url)
+        XCTAssertEqual(cleared.label, .none)
+        XCTAssertTrue(cleared.tagNames.isEmpty)
+        XCTAssertTrue(cleared.comment.isEmpty)
+    }
+
     func testPerformanceExample() throws {
         // This is an example of a performance test case.
         self.measure {

--- a/design.md
+++ b/design.md
@@ -54,7 +54,7 @@ Rules derived from `ContentView`, `SidebarView`, and `ImageDetailView`.
 2. **Sidebar owns library location** — Selection is a single enum: All Images, Folder, or Contact Sheet. External drive rows are status only — not navigation targets.
 3. **Location change clears browsing state** — On library selection change, clear image selection, focus, quick preview, and detail view.
 4. **Detail is a canvas overlay** — Double-click opens `ImageDetailView` over the library detail column (opacity / hit-testing), not a pushed navigation destination or new column.
-5. **Inspector yields to focused viewing** — Entering detail hides the inspector by default; leaving detail restores it.
+5. **Inspector stays with detail** — Entering detail keeps the metadata inspector available so Finder labels, tags, and comments can be edited while viewing.
 6. **Sidebar is collapsible** — Width 240–360 (ideal 280). Auto-collapse to `.detailOnly` below 220 pt measured width.
 7. **Unified chrome** — Window uses unified toolbar with no title. Keep `.navigationTitle("")` unless a mode truly needs a title.
 8. **Window scale** — Minimum about 1100×700; default launch size stays large enough for sidebar + grid + inspector.
@@ -206,6 +206,7 @@ Disable animations while the grid size slider is dragging. Prefer `MicroficheMot
 
 ### Detail & metadata
 - **Files:** `Microfiche/Views/ImageDetailView.swift`, `PreviewView.swift`
+- **Native metadata:** `NativeFileMetadataService` + `FinderLabel` read/write Finder color labels, tags, and comments; inspector `FinderLabelPicker` is the primary label UI.
 
 ---
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Makes the detail inspector a proper panel for editing **native macOS Finder metadata**, with color labels as the primary control.

- Adds `FinderLabel` + `NativeFileMetadataService` to read/write Finder color labels (`labelNumber`), tags (`tagNames`), and Finder comments
- Replaces free-text “Labels” chips with a Finder-style color-dot picker (None + Gray/Green/Purple/Blue/Yellow/Orange/Red)
- Tags and comments now sync with Finder; “Where From” stays Microfiche-local
- Migrates legacy local label names like `"Red"` onto the matching Finder color
- Keeps the inspector open when entering detail view so metadata can be edited while viewing
- Wires the detail “More” menu with Reveal in Finder / Copy Path
- Adds unit coverage for label migration and native metadata round-trips

## Test plan
- [ ] Open an image in detail view and confirm the inspector stays visible
- [ ] Set a Finder color label and verify it appears in Finder Get Info / list view
- [ ] Add/remove Finder tags and a comment; confirm they show in Finder
- [ ] Reload a file that previously had local `"Red"`/`"Blue"` labels and confirm migration
- [ ] Confirm Where From still saves locally without writing to the file
- [ ] Run `MicroficheTests` (Finder label migration + native metadata round-trip)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f9f0d-b88b-7c0d-87c6-4607f0280c03"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f9f0d-b88b-7c0d-87c6-4607f0280c03"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

