### PR TITLE
Add welcome onboarding sequence with testing toggle

### DIFF
--- a/Microfiche/ContentView.swift
+++ b/Microfiche/ContentView.swift
@@ -94,6 +94,7 @@ struct ContentView: View {
     @AppStorage("lastSelectedLibraryFolderID") private var lastSelectedLibraryFolderID = ""
     @StateObject private var libraryStorage = LibraryStorage.shared
     @StateObject private var contactSheetStorage = ContactSheetStorage.shared
+    @StateObject private var userPreferences = UserPreferences.shared
 
     let supportedExtensions = ["jpg", "jpeg", "png", "pdf", "svg", "gif", "tiff"]
 
@@ -267,6 +268,7 @@ struct ContentView: View {
                 }
                 .background(KeyboardEventHandlingView(
                     onDeletePressed: { bypassConfirmation in
+                        guard !userPreferences.isPresentingOnboarding else { return }
                         let filesToDelete = imageFiles.filter { selectedImageFileIDs.contains($0.id) }
                         if !filesToDelete.isEmpty {
                             if bypassConfirmation || dontAskAgain {
@@ -278,7 +280,9 @@ struct ContentView: View {
                         }
                     },
                     onEscapePressed: {
-                        if detailViewFile != nil {
+                        if userPreferences.isPresentingOnboarding {
+                            userPreferences.completeOnboarding()
+                        } else if detailViewFile != nil {
                             closeImageDetail()
                         } else if isQuickPreviewPresented {
                             dismissQuickPreview()
@@ -287,8 +291,14 @@ struct ContentView: View {
                             focusedImageFileID = nil
                         }
                     },
-                    onSpacebarPressed: toggleQuickPreview,
-                    onArrowPressed: handleArrowKey
+                    onSpacebarPressed: {
+                        guard !userPreferences.isPresentingOnboarding else { return }
+                        toggleQuickPreview()
+                    },
+                    onArrowPressed: { direction in
+                        guard !userPreferences.isPresentingOnboarding else { return }
+                        handleArrowKey(direction)
+                    }
                 ))
                 .alert("Move to Trash?", isPresented: $showDeleteAlert) {
                     Button("Move to Trash", role: .destructive) {
@@ -325,10 +335,23 @@ struct ContentView: View {
                     }
                     .transition(.opacity)
                 }
+
+                if userPreferences.isPresentingOnboarding {
+                    OnboardingView(
+                        onLinkFolder: linkFolder,
+                        onFinished: {
+                            userPreferences.completeOnboarding()
+                        }
+                    )
+                    .transition(.opacity)
+                    .zIndex(10)
+                }
         }
         .animation(MicroficheMotion.snap, value: isQuickPreviewPresented)
+        .animation(MicroficheMotion.transition, value: userPreferences.isPresentingOnboarding)
         .task {
             restoreLibrarySelection()
+            userPreferences.evaluateLaunchPresentation()
         }
     }
 

--- a/Microfiche/MicroficheApp.swift
+++ b/Microfiche/MicroficheApp.swift
@@ -41,6 +41,18 @@ struct MicroficheApp: App {
                 }
                 .keyboardShortcut("i", modifiers: [.command, .shift])
             }
+
+            CommandGroup(after: .help) {
+                Divider()
+                Button("Replay Welcome Onboarding") {
+                    UserPreferences.shared.replayOnboarding()
+                }
+                .disabled(!UserPreferences.shared.isOnboardingEnabled)
+            }
+        }
+
+        Settings {
+            SettingsView()
         }
     }
 

--- a/Microfiche/Services/UserPreferences.swift
+++ b/Microfiche/Services/UserPreferences.swift
@@ -1,0 +1,76 @@
+//
+//  UserPreferences.swift
+//  Microfiche
+//
+//  App-wide preferences persisted via UserDefaults.
+//
+
+import Combine
+import Foundation
+
+@MainActor
+final class UserPreferences: ObservableObject {
+    static let shared = UserPreferences()
+
+    enum Keys {
+        static let hasCompletedOnboarding = "hasCompletedOnboarding"
+        static let isOnboardingEnabled = "isOnboardingEnabled"
+    }
+
+    private let defaults: UserDefaults
+
+    /// Master switch for the welcome sequence. Off hides onboarding (useful while testing).
+    @Published var isOnboardingEnabled: Bool {
+        didSet {
+            defaults.set(isOnboardingEnabled, forKey: Keys.isOnboardingEnabled)
+            if !isOnboardingEnabled {
+                isPresentingOnboarding = false
+            } else if shouldPresentOnboarding {
+                isPresentingOnboarding = true
+            }
+        }
+    }
+
+    /// True after the user finishes or skips the welcome sequence.
+    @Published var hasCompletedOnboarding: Bool {
+        didSet {
+            defaults.set(hasCompletedOnboarding, forKey: Keys.hasCompletedOnboarding)
+        }
+    }
+
+    /// Live presentation flag for the onboarding overlay.
+    @Published var isPresentingOnboarding = false
+
+    var shouldPresentOnboarding: Bool {
+        isOnboardingEnabled && !hasCompletedOnboarding
+    }
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+
+        if defaults.object(forKey: Keys.isOnboardingEnabled) == nil {
+            defaults.set(true, forKey: Keys.isOnboardingEnabled)
+        }
+
+        self.isOnboardingEnabled = defaults.bool(forKey: Keys.isOnboardingEnabled)
+        self.hasCompletedOnboarding = defaults.bool(forKey: Keys.hasCompletedOnboarding)
+    }
+
+    /// Call once at launch to surface onboarding for first-time (or reset) users.
+    func evaluateLaunchPresentation() {
+        guard shouldPresentOnboarding else { return }
+        isPresentingOnboarding = true
+    }
+
+    func completeOnboarding() {
+        hasCompletedOnboarding = true
+        isPresentingOnboarding = false
+    }
+
+    /// Testing helper: clear completion and show the sequence immediately.
+    func replayOnboarding() {
+        guard isOnboardingEnabled else { return }
+        hasCompletedOnboarding = false
+        isPresentingOnboarding = true
+    }
+}

--- a/Microfiche/Views/OnboardingView.swift
+++ b/Microfiche/Views/OnboardingView.swift
@@ -1,0 +1,199 @@
+//
+//  OnboardingView.swift
+//  Microfiche
+//
+//  Multi-step welcome sequence that introduces Microfiche's value proposition.
+//
+
+import SwiftUI
+
+struct OnboardingView: View {
+    let onLinkFolder: () -> Void
+    let onFinished: () -> Void
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var stepIndex = 0
+
+    private var steps: [OnboardingStep] {
+        OnboardingStep.all
+    }
+
+    private var isLastStep: Bool {
+        stepIndex >= steps.count - 1
+    }
+
+    var body: some View {
+        ZStack {
+            Color.black.opacity(0.55)
+                .ignoresSafeArea()
+
+            LiquidGlassPanel(cornerRadius: 18) {
+                VStack(spacing: 0) {
+                    HStack {
+                        Spacer(minLength: 0)
+                        Button("Skip") {
+                            finish()
+                        }
+                        .buttonStyle(.plain)
+                        .foregroundStyle(.secondary)
+                        .help("Skip welcome onboarding")
+                    }
+                    .padding(.horizontal, 28)
+                    .padding(.top, 20)
+
+                    OnboardingStepPage(step: steps[stepIndex], showsBrand: stepIndex == 0)
+                        .id(steps[stepIndex].id)
+                        .padding(.horizontal, 36)
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                        .transition(
+                            reduceMotion
+                                ? .opacity
+                                : .asymmetric(
+                                    insertion: .opacity.combined(with: .move(edge: .trailing)),
+                                    removal: .opacity.combined(with: .move(edge: .leading))
+                                )
+                        )
+                        .animation(MicroficheMotion.transition(reducedMotion: reduceMotion), value: stepIndex)
+
+                    VStack(spacing: 18) {
+                        HStack(spacing: 7) {
+                            ForEach(steps.indices, id: \.self) { index in
+                                Circle()
+                                    .fill(index == stepIndex ? Color.accentColor : Color.secondary.opacity(0.35))
+                                    .frame(width: index == stepIndex ? 8 : 6, height: index == stepIndex ? 8 : 6)
+                                    .animation(MicroficheMotion.snap(reducedMotion: reduceMotion), value: stepIndex)
+                            }
+                        }
+                        .accessibilityElement(children: .ignore)
+                        .accessibilityLabel("Step \(stepIndex + 1) of \(steps.count)")
+
+                        HStack(spacing: 12) {
+                            if stepIndex > 0 {
+                                Button("Back") {
+                                    withAnimation(MicroficheMotion.transition(reducedMotion: reduceMotion)) {
+                                        stepIndex -= 1
+                                    }
+                                }
+                            }
+
+                            Spacer(minLength: 0)
+
+                            if isLastStep {
+                                Button("Link a Folder") {
+                                    finish()
+                                    onLinkFolder()
+                                }
+                                .buttonStyle(.borderedProminent)
+                                .keyboardShortcut(.defaultAction)
+
+                                Button("Start Browsing") {
+                                    finish()
+                                }
+                                .buttonStyle(.bordered)
+                            } else {
+                                Button("Continue") {
+                                    withAnimation(MicroficheMotion.transition(reducedMotion: reduceMotion)) {
+                                        stepIndex += 1
+                                    }
+                                }
+                                .buttonStyle(.borderedProminent)
+                                .keyboardShortcut(.defaultAction)
+                            }
+                        }
+                    }
+                    .padding(.horizontal, 28)
+                    .padding(.bottom, 28)
+                    .padding(.top, 8)
+                }
+            }
+            .frame(width: 520, height: 420)
+            .accessibilityElement(children: .contain)
+            .accessibilityAddTraits(.isModal)
+        }
+    }
+
+    private func finish() {
+        onFinished()
+    }
+}
+
+// MARK: - Step Model
+
+struct OnboardingStep: Identifiable, Equatable {
+    let id: String
+    let symbolName: String
+    let title: String
+    let message: String
+
+    static let all: [OnboardingStep] = [
+        OnboardingStep(
+            id: "welcome",
+            symbolName: "photo.on.rectangle.angled",
+            title: "Your library, left in place",
+            message: "Microfiche browses photos where they already live. No import, no copies — just a durable view of your folders and drives."
+        ),
+        OnboardingStep(
+            id: "folders",
+            symbolName: "folder.badge.plus",
+            title: "Link folders and drives",
+            message: "Add folders from your Mac or external volumes. Microfiche remembers them and reconnects when a drive comes back online."
+        ),
+        OnboardingStep(
+            id: "contact-sheets",
+            symbolName: "rectangle.stack",
+            title: "Curate with Contact Sheets",
+            message: "Gather selects into Contact Sheets that stay available even if the original drive is offline."
+        ),
+        OnboardingStep(
+            id: "metadata",
+            symbolName: "tag",
+            title: "Labels, tags, and notes that stick",
+            message: "Edit Finder labels, tags, and comments right from the inspector — written where Finder and other apps can see them."
+        )
+    ]
+}
+
+// MARK: - Step Page
+
+private struct OnboardingStepPage: View {
+    let step: OnboardingStep
+    let showsBrand: Bool
+
+    var body: some View {
+        VStack(spacing: 18) {
+            Image(systemName: step.symbolName)
+                .font(.system(size: 40, weight: .medium))
+                .foregroundStyle(.secondary)
+                .symbolRenderingMode(.hierarchical)
+                .frame(width: 64, height: 64)
+                .accessibilityHidden(true)
+
+            VStack(spacing: 8) {
+                if showsBrand {
+                    Text("Microfiche")
+                        .font(.system(size: 13, weight: .semibold))
+                        .foregroundStyle(.secondary)
+                        .textCase(.uppercase)
+                        .tracking(1.1)
+                }
+
+                Text(step.title)
+                    .font(.system(size: 24, weight: .semibold))
+                    .multilineTextAlignment(.center)
+
+                Text(step.message)
+                    .font(.system(size: 14, weight: .regular))
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+                    .frame(maxWidth: 380)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .accessibilityElement(children: .combine)
+    }
+}
+
+#Preview {
+    OnboardingView(onLinkFolder: {}, onFinished: {})
+}

--- a/Microfiche/Views/SettingsView.swift
+++ b/Microfiche/Views/SettingsView.swift
@@ -1,0 +1,55 @@
+//
+//  SettingsView.swift
+//  Microfiche
+//
+//  App Settings (⌘,) — includes onboarding controls for testing.
+//
+
+import SwiftUI
+
+struct SettingsView: View {
+    @ObservedObject private var preferences = UserPreferences.shared
+
+    var body: some View {
+        Form {
+            Section {
+                Toggle("Show welcome onboarding", isOn: $preferences.isOnboardingEnabled)
+                    .help("When enabled, Microfiche presents the welcome sequence until it is completed or skipped.")
+
+                HStack {
+                    Button("Replay Onboarding") {
+                        preferences.replayOnboarding()
+                    }
+                    .disabled(!preferences.isOnboardingEnabled)
+
+                    Spacer(minLength: 0)
+
+                    Text(statusLabel)
+                        .font(.system(size: 12))
+                        .foregroundStyle(.secondary)
+                }
+            } header: {
+                Text("Onboarding")
+            } footer: {
+                Text("Turn this off to skip the welcome sequence while testing. Use Replay to walk through it again.")
+            }
+        }
+        .formStyle(.grouped)
+        .frame(width: 420)
+        .padding()
+    }
+
+    private var statusLabel: String {
+        if !preferences.isOnboardingEnabled {
+            return "Disabled"
+        }
+        if preferences.isPresentingOnboarding {
+            return "Showing now"
+        }
+        return preferences.hasCompletedOnboarding ? "Completed" : "Pending"
+    }
+}
+
+#Preview {
+    SettingsView()
+}

--- a/MicroficheTests/MicroficheTests.swift
+++ b/MicroficheTests/MicroficheTests.swift
@@ -460,4 +460,54 @@ final class MicroficheTests: XCTestCase {
         }
     }
 
+    @MainActor
+    func testUserPreferencesDefaultsEnableOnboardingUntilCompleted() {
+        let suiteName = "microfiche.tests.onboarding.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let preferences = UserPreferences(defaults: defaults)
+
+        XCTAssertTrue(preferences.isOnboardingEnabled)
+        XCTAssertFalse(preferences.hasCompletedOnboarding)
+        XCTAssertTrue(preferences.shouldPresentOnboarding)
+
+        preferences.evaluateLaunchPresentation()
+        XCTAssertTrue(preferences.isPresentingOnboarding)
+
+        preferences.completeOnboarding()
+        XCTAssertTrue(preferences.hasCompletedOnboarding)
+        XCTAssertFalse(preferences.isPresentingOnboarding)
+        XCTAssertFalse(preferences.shouldPresentOnboarding)
+    }
+
+    @MainActor
+    func testUserPreferencesTestingToggleAndReplay() {
+        let suiteName = "microfiche.tests.onboarding-toggle.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let preferences = UserPreferences(defaults: defaults)
+        preferences.completeOnboarding()
+
+        preferences.isOnboardingEnabled = false
+        XCTAssertFalse(preferences.isPresentingOnboarding)
+        preferences.replayOnboarding()
+        XCTAssertFalse(preferences.isPresentingOnboarding)
+        XCTAssertTrue(preferences.hasCompletedOnboarding)
+
+        preferences.isOnboardingEnabled = true
+        preferences.replayOnboarding()
+        XCTAssertFalse(preferences.hasCompletedOnboarding)
+        XCTAssertTrue(preferences.isPresentingOnboarding)
+        XCTAssertTrue(preferences.shouldPresentOnboarding)
+    }
+
+    func testOnboardingSequenceCoversValueProposition() {
+        let steps = OnboardingStep.all
+        XCTAssertEqual(steps.count, 4)
+        XCTAssertEqual(steps.map(\.id), ["welcome", "folders", "contact-sheets", "metadata"])
+        XCTAssertTrue(steps.allSatisfy { !$0.title.isEmpty && !$0.message.isEmpty && !$0.symbolName.isEmpty })
+    }
+
 }

--- a/design.md
+++ b/design.md
@@ -208,6 +208,12 @@ Disable animations while the grid size slider is dragging. Prefer `MicroficheMot
 - **Files:** `Microfiche/Views/ImageDetailView.swift`, `PreviewView.swift`
 - **Native metadata:** `NativeFileMetadataService` + `FinderLabel` read/write Finder color labels, tags, and comments; inspector `FinderLabelPicker` is the primary label UI.
 
+### Welcome onboarding
+- **Files:** `Microfiche/Views/OnboardingView.swift`, `SettingsView.swift`, `Services/UserPreferences.swift`
+- Full-window dimmed overlay + `LiquidGlassPanel` (same modal pattern as quick preview).
+- Shows once until completed/skipped when **Settings → Onboarding → Show welcome onboarding** is on.
+- Testing: toggle the setting off to suppress; use **Replay Onboarding** or **Help → Replay Welcome Onboarding** to walk through again.
+
 ---
 
 ## Future Enhancements


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Adds a 4-step welcome onboarding overlay that introduces Microfiche’s value prop: in-place library, linked folders/drives, Contact Sheets, and Finder metadata.
- Persists completion and an enable/disable flag in `UserPreferences` (UserDefaults).
- Adds **Settings → Onboarding** with a “Show welcome onboarding” toggle and **Replay Onboarding** for testing, plus **Help → Replay Welcome Onboarding**.

## How to test
1. Launch with a fresh defaults state (or use Replay) and confirm the overlay appears.
2. Walk through Continue → final CTAs (**Link a Folder** / **Start Browsing**); confirm it doesn’t show again on relaunch.
3. Open **Settings (⌘,) → Onboarding**, turn the toggle **off**, and confirm the sequence no longer appears / dismisses if showing.
4. Turn the toggle **on**, click **Replay Onboarding**, and confirm the sequence returns.
5. Press Esc or Skip and confirm onboarding is marked completed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f9f14-0bcf-72bc-9c0f-f533a61ea9af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f9f14-0bcf-72bc-9c0f-f533a61ea9af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

