### PR TITLE
Add archive folder moves and list contact-sheet menus

### DIFF
--- a/Microfiche/ContentView.swift
+++ b/Microfiche/ContentView.swift
@@ -36,6 +36,10 @@ enum ArrowDirection {
     case up, down, left, right
 }
 
+extension Notification.Name {
+    static let microficheMoveSelectionToArchive = Notification.Name("microficheMoveSelectionToArchive")
+}
+
 enum ImageNavigation {
     static func nextIndex(
         from currentIndex: Int,
@@ -84,6 +88,9 @@ struct ContentView: View {
     @State private var showDeleteAlert: Bool = false
     @State private var dontAskAgain: Bool = UserDefaults.standard.bool(forKey: "dontAskDeleteConfirm")
     @State private var pendingDeleteFiles: [ImageFile] = []
+    @State private var showChooseArchiveAlert = false
+    @State private var pendingArchiveFiles: [ImageFile] = []
+    @State private var archiveErrorMessage: String?
     @State private var isQuickPreviewPresented = false
     @State private var scrollToID: UUID?
     @State private var gridColumnCount: Int = 1
@@ -95,6 +102,7 @@ struct ContentView: View {
     @StateObject private var libraryStorage = LibraryStorage.shared
     @StateObject private var contactSheetStorage = ContactSheetStorage.shared
     @StateObject private var userPreferences = UserPreferences.shared
+    @StateObject private var archiveFolderStore = ArchiveFolderStore.shared
 
     let supportedExtensions = ["jpg", "jpeg", "png", "pdf", "svg", "gif", "tiff"]
 
@@ -155,7 +163,8 @@ struct ContentView: View {
                         scrollToID: $scrollToID,
                         onRename: renameFile,
                         contactSheets: contactSheetStorage.contactSheets,
-                        onAddToContactSheet: handleAddToContactSheet
+                        onAddToContactSheet: handleAddToContactSheet,
+                        onArchive: handleArchiveRequest(for:)
                     )
                     .opacity(detailViewFile == nil ? 1 : 0)
                     .allowsHitTesting(detailViewFile == nil)
@@ -266,6 +275,17 @@ struct ContentView: View {
                         pendingDeleteFiles = []
                     }
                 }
+                .onChange(of: showChooseArchiveAlert) { _, isShowing in
+                    if !isShowing, archiveFolderStore.resolvedURL() == nil {
+                        pendingArchiveFiles = []
+                    }
+                }
+                .onReceive(NotificationCenter.default.publisher(for: .microficheMoveSelectionToArchive)) { _ in
+                    guard !userPreferences.isPresentingOnboarding else { return }
+                    let selected = imageFiles.filter { selectedImageFileIDs.contains($0.id) }
+                    guard !selected.isEmpty else { return }
+                    requestArchive(for: selected)
+                }
                 .background(KeyboardEventHandlingView(
                     onDeletePressed: { bypassConfirmation in
                         guard !userPreferences.isPresentingOnboarding else { return }
@@ -327,6 +347,32 @@ struct ContentView: View {
                     Button("OK") { externalDriveNotice = nil }
                 } message: {
                     Text(externalDriveNotice ?? "")
+                }
+                .alert("Choose Archive Folder", isPresented: $showChooseArchiveAlert) {
+                    Button("Choose…") {
+                        if archiveFolderStore.chooseFolder() {
+                            moveFilesToArchive(pendingArchiveFiles)
+                        }
+                        pendingArchiveFiles = []
+                    }
+                    .keyboardShortcut(.defaultAction)
+
+                    Button("Cancel", role: .cancel) {
+                        pendingArchiveFiles = []
+                    }
+                } message: {
+                    Text("Pick a folder where Microfiche should move archived images.")
+                }
+                .alert(
+                    "Couldn’t Archive",
+                    isPresented: Binding(
+                        get: { archiveErrorMessage != nil },
+                        set: { if !$0 { archiveErrorMessage = nil } }
+                    )
+                ) {
+                    Button("OK") { archiveErrorMessage = nil }
+                } message: {
+                    Text(archiveErrorMessage ?? "")
                 }
 
                 if isQuickPreviewPresented, let file = focusedImageFile {
@@ -569,6 +615,91 @@ struct ContentView: View {
         requestScrollToFocusedImage()
     }
 
+    // MARK: - Archive
+
+    private func handleArchiveRequest(for file: ImageFile) {
+        if selectedImageFileIDs.contains(file.id), selectedImageFileIDs.count > 1 {
+            let selected = imageFiles.filter { selectedImageFileIDs.contains($0.id) }
+            requestArchive(for: selected)
+        } else {
+            requestArchive(for: [file])
+        }
+    }
+
+    private func requestArchive(for files: [ImageFile]) {
+        guard !files.isEmpty else { return }
+
+        if archiveFolderStore.resolvedURL() != nil {
+            moveFilesToArchive(files)
+            return
+        }
+
+        pendingArchiveFiles = files
+        showChooseArchiveAlert = true
+    }
+
+    private func moveFilesToArchive(_ files: [ImageFile]) {
+        guard let archiveURL = archiveFolderStore.resolvedURL() else {
+            pendingArchiveFiles = files
+            showChooseArchiveAlert = true
+            return
+        }
+
+        let archivedIDs = Set(files.map(\.id))
+        let deletedDetailIndex = detailViewFile.flatMap { detailFile in
+            archivedIDs.contains(detailFile.id)
+                ? imageFiles.firstIndex(where: { $0.id == detailFile.id })
+                : nil
+        }
+        let wasPreviewedArchived = isQuickPreviewPresented
+            && focusedImageFileID.map(archivedIDs.contains) == true
+        var previewIndex: Int?
+        if wasPreviewedArchived,
+           let focusedImageFileID,
+           let idx = imageFiles.firstIndex(where: { $0.id == focusedImageFileID }) {
+            previewIndex = idx
+        }
+        let originalFilesSnapshot = imageFiles
+        let anchorIndexBeforeArchive: Int? = files
+            .compactMap { file in originalFilesSnapshot.firstIndex(of: file) }
+            .min()
+
+        var movedCount = 0
+        var lastError: Error?
+
+        for file in files {
+            do {
+                let destination = try FileArchiver.move(file.url, intoArchive: archiveURL)
+                ImageMetadataStore.shared.move(from: file.url, to: destination)
+                ImageCache.shared.clearCacheForFile(at: file.url)
+                PreviewImageCache.shared.clearCacheForFile(at: file.url)
+                imageFiles.removeAll { $0.id == file.id }
+                selectedImageFileIDs.remove(file.id)
+                movedCount += 1
+            } catch {
+                lastError = error
+                print("Error archiving file: \(error)")
+            }
+        }
+
+        if movedCount == 0 {
+            archiveErrorMessage = lastError?.localizedDescription
+                ?? "Unable to move the selected images to the archive folder."
+            return
+        }
+
+        if movedCount < files.count {
+            archiveErrorMessage = "Moved \(movedCount) of \(files.count) images. \(lastError?.localizedDescription ?? "Some files could not be archived.")"
+        }
+
+        updateFocusAfterRemovingFiles(
+            removedDetailIndex: deletedDetailIndex,
+            wasPreviewedRemoved: wasPreviewedArchived,
+            previewIndex: previewIndex,
+            anchorIndexBeforeRemoval: anchorIndexBeforeArchive
+        )
+    }
+
     // MARK: - Delete
 
     private func moveFilesToTrash(_ files: [ImageFile]) {
@@ -608,8 +739,22 @@ struct ContentView: View {
             PreviewImageCache.shared.clearCacheForFile(at: url)
         }
 
-        if let deletedDetailIndex {
-            let nextIndex = min(deletedDetailIndex, imageFiles.count - 1)
+        updateFocusAfterRemovingFiles(
+            removedDetailIndex: deletedDetailIndex,
+            wasPreviewedRemoved: wasPreviewedDeleted,
+            previewIndex: previewIndex,
+            anchorIndexBeforeRemoval: anchorIndexBeforeDeletion
+        )
+    }
+
+    private func updateFocusAfterRemovingFiles(
+        removedDetailIndex: Int?,
+        wasPreviewedRemoved: Bool,
+        previewIndex: Int?,
+        anchorIndexBeforeRemoval: Int?
+    ) {
+        if let removedDetailIndex {
+            let nextIndex = min(removedDetailIndex, imageFiles.count - 1)
             if imageFiles.indices.contains(nextIndex) {
                 let nextFile = imageFiles[nextIndex]
                 detailViewFile = nextFile
@@ -625,7 +770,7 @@ struct ContentView: View {
             return
         }
 
-        if wasPreviewedDeleted {
+        if wasPreviewedRemoved {
             let remaining = imageFiles
             if let idx = previewIndex {
                 let nextIdx = idx < remaining.count ? idx : (remaining.count - 1)
@@ -642,27 +787,28 @@ struct ContentView: View {
                 isQuickPreviewPresented = false
                 focusedImageFileID = nil
             }
-        } else {
-            let remaining = imageFiles
-            if let idx = anchorIndexBeforeDeletion {
-                let candidate = idx < remaining.count ? idx : (remaining.count - 1)
-                if candidate >= 0, remaining.indices.contains(candidate) {
-                    let nextFile = remaining[candidate]
-                    selectedImageFileIDs = [nextFile.id]
-                    focusedImageFileID = nextFile.id
-                    scrollToID = nextFile.id
-                } else {
-                    selectedImageFileIDs = []
-                    focusedImageFileID = nil
-                }
-            } else if let first = remaining.first {
-                selectedImageFileIDs = [first.id]
-                focusedImageFileID = first.id
-                scrollToID = first.id
+            return
+        }
+
+        let remaining = imageFiles
+        if let idx = anchorIndexBeforeRemoval {
+            let candidate = idx < remaining.count ? idx : (remaining.count - 1)
+            if candidate >= 0, remaining.indices.contains(candidate) {
+                let nextFile = remaining[candidate]
+                selectedImageFileIDs = [nextFile.id]
+                focusedImageFileID = nextFile.id
+                scrollToID = nextFile.id
             } else {
                 selectedImageFileIDs = []
                 focusedImageFileID = nil
             }
+        } else if let first = remaining.first {
+            selectedImageFileIDs = [first.id]
+            focusedImageFileID = first.id
+            scrollToID = first.id
+        } else {
+            selectedImageFileIDs = []
+            focusedImageFileID = nil
         }
     }
 

--- a/Microfiche/MicroficheApp.swift
+++ b/Microfiche/MicroficheApp.swift
@@ -29,6 +29,11 @@ struct MicroficheApp: App {
         .windowToolbarStyle(.unified(showsTitle: false))
         .commands {
             CommandGroup(after: .newItem) {
+                Button("Move to Archive") {
+                    NotificationCenter.default.post(name: .microficheMoveSelectionToArchive, object: nil)
+                }
+                .keyboardShortcut("a", modifiers: [.command, .shift])
+
                 Divider()
                 Button("Clear Image Cache") {
                     ImageCache.shared.clearCache()

--- a/Microfiche/Services/ArchiveFolderStore.swift
+++ b/Microfiche/Services/ArchiveFolderStore.swift
@@ -1,0 +1,140 @@
+//
+//  ArchiveFolderStore.swift
+//  Microfiche
+//
+//  Persists a security-scoped bookmark for the user-defined archive folder.
+//
+
+import AppKit
+import Combine
+import Foundation
+
+@MainActor
+final class ArchiveFolderStore: ObservableObject {
+    static let shared = ArchiveFolderStore()
+
+    enum Keys {
+        static let bookmark = "archiveFolderBookmark"
+        static let displayName = "archiveFolderDisplayName"
+    }
+
+    private let defaults: UserDefaults
+    private let fileManager: FileManager
+    private var activeSecurityScopedURL: URL?
+
+    @Published private(set) var displayName: String?
+    @Published private(set) var isAvailable: Bool = false
+
+    var hasConfiguredFolder: Bool {
+        defaults.data(forKey: Keys.bookmark) != nil
+    }
+
+    init(
+        defaults: UserDefaults = .standard,
+        fileManager: FileManager = .default
+    ) {
+        self.defaults = defaults
+        self.fileManager = fileManager
+        refresh()
+    }
+
+    deinit {
+        activeSecurityScopedURL?.stopAccessingSecurityScopedResource()
+    }
+
+    /// Presents an open panel and stores the chosen folder bookmark.
+    @discardableResult
+    func chooseFolder() -> Bool {
+        let openPanel = NSOpenPanel()
+        openPanel.canChooseFiles = false
+        openPanel.canChooseDirectories = true
+        openPanel.allowsMultipleSelection = false
+        openPanel.prompt = "Choose Archive Folder"
+        openPanel.message = "Images moved to Archive are stored in this folder."
+
+        guard openPanel.runModal() == .OK, let url = openPanel.url else {
+            return false
+        }
+        return setFolder(url)
+    }
+
+    @discardableResult
+    func setFolder(_ url: URL) -> Bool {
+        let standardized = url.standardizedFileURL.resolvingSymlinksInPath()
+        do {
+            let bookmark = try standardized.bookmarkData(
+                options: [.withSecurityScope],
+                includingResourceValuesForKeys: nil,
+                relativeTo: nil
+            )
+            defaults.set(bookmark, forKey: Keys.bookmark)
+            defaults.set(standardized.lastPathComponent, forKey: Keys.displayName)
+            refresh()
+            return isAvailable
+        } catch {
+            print("Unable to remember archive folder \(standardized.path): \(error)")
+            return false
+        }
+    }
+
+    func clearFolder() {
+        activeSecurityScopedURL?.stopAccessingSecurityScopedResource()
+        activeSecurityScopedURL = nil
+        defaults.removeObject(forKey: Keys.bookmark)
+        defaults.removeObject(forKey: Keys.displayName)
+        displayName = nil
+        isAvailable = false
+    }
+
+    /// Resolves the archive folder, refreshing a stale bookmark when needed.
+    func resolvedURL() -> URL? {
+        refresh()
+        return activeSecurityScopedURL
+    }
+
+    func refresh() {
+        guard let bookmark = defaults.data(forKey: Keys.bookmark) else {
+            activeSecurityScopedURL?.stopAccessingSecurityScopedResource()
+            activeSecurityScopedURL = nil
+            displayName = nil
+            isAvailable = false
+            return
+        }
+
+        var isStale = false
+        let resolved = try? URL(
+            resolvingBookmarkData: bookmark,
+            options: [.withSecurityScope],
+            relativeTo: nil,
+            bookmarkDataIsStale: &isStale
+        )
+
+        guard let resolved,
+              fileManager.fileExists(atPath: resolved.path) else {
+            activeSecurityScopedURL?.stopAccessingSecurityScopedResource()
+            activeSecurityScopedURL = nil
+            displayName = defaults.string(forKey: Keys.displayName)
+            isAvailable = false
+            return
+        }
+
+        if activeSecurityScopedURL != resolved {
+            activeSecurityScopedURL?.stopAccessingSecurityScopedResource()
+            _ = resolved.startAccessingSecurityScopedResource()
+            activeSecurityScopedURL = resolved
+        }
+
+        if isStale,
+           let refreshed = try? resolved.bookmarkData(
+               options: [.withSecurityScope],
+               includingResourceValuesForKeys: nil,
+               relativeTo: nil
+           ) {
+            defaults.set(refreshed, forKey: Keys.bookmark)
+        }
+
+        displayName = resolved.lastPathComponent
+        defaults.set(displayName, forKey: Keys.displayName)
+        isAvailable = true
+    }
+}

--- a/Microfiche/Services/FileArchiver.swift
+++ b/Microfiche/Services/FileArchiver.swift
@@ -1,0 +1,59 @@
+//
+//  FileArchiver.swift
+//  Microfiche
+//
+//  Moves image files into a user-defined archive folder.
+//
+
+import Foundation
+
+enum FileArchiver {
+    /// Returns a destination URL in `directory` that does not collide with existing files.
+    /// Uses `name.ext`, then `name-1.ext`, `name-2.ext`, …
+    static func uniqueDestination(
+        for source: URL,
+        in directory: URL,
+        fileManager: FileManager = .default
+    ) -> URL {
+        let baseName = source.deletingPathExtension().lastPathComponent
+        let ext = source.pathExtension
+        var candidate = directory.appendingPathComponent(source.lastPathComponent)
+
+        var suffix = 1
+        while fileManager.fileExists(atPath: candidate.path) {
+            let numbered = ext.isEmpty ? "\(baseName)-\(suffix)" : "\(baseName)-\(suffix).\(ext)"
+            candidate = directory.appendingPathComponent(numbered)
+            suffix += 1
+        }
+        return candidate
+    }
+
+    /// Moves `source` into `directory`, renaming on collision. Returns the final URL.
+    @discardableResult
+    static func move(
+        _ source: URL,
+        intoArchive directory: URL,
+        fileManager: FileManager = .default
+    ) throws -> URL {
+        var isDirectory: ObjCBool = false
+        guard fileManager.fileExists(atPath: directory.path, isDirectory: &isDirectory),
+              isDirectory.boolValue else {
+            throw ArchiveError.destinationUnavailable
+        }
+
+        let destination = uniqueDestination(for: source, in: directory, fileManager: fileManager)
+        try fileManager.moveItem(at: source, to: destination)
+        return destination
+    }
+
+    enum ArchiveError: LocalizedError {
+        case destinationUnavailable
+
+        var errorDescription: String? {
+            switch self {
+            case .destinationUnavailable:
+                return "The archive folder is unavailable."
+            }
+        }
+    }
+}

--- a/Microfiche/Views/MainContentView.swift
+++ b/Microfiche/Views/MainContentView.swift
@@ -25,6 +25,7 @@ struct MainContentView: View {
     let onRename: (URL, String) -> Void
     let contactSheets: [ContactSheet]
     let onAddToContactSheet: (UUID, URL) -> Void
+    let onArchive: (ImageFile) -> Void
     var body: some View {
         ZStack {
             mainCanvasBackground
@@ -52,7 +53,8 @@ struct MainContentView: View {
                                 columnCount: $gridColumnCount,
                                 onRename: onRename,
                                 contactSheets: contactSheets,
-                                onAddToContactSheet: onAddToContactSheet
+                                onAddToContactSheet: onAddToContactSheet,
+                                onArchive: onArchive
                             )
                         } else {
                             ImageListView(
@@ -61,7 +63,10 @@ struct MainContentView: View {
                                 onSelectImage: onSelectImage,
                                 onDoubleClickImage: onDoubleClickImage,
                                 scrollToID: $scrollToID,
-                                onRename: onRename
+                                onRename: onRename,
+                                contactSheets: contactSheets,
+                                onAddToContactSheet: onAddToContactSheet,
+                                onArchive: onArchive
                             )
                         }
                     }
@@ -214,6 +219,7 @@ struct ImageGridView: View {
     let onRename: (URL, String) -> Void
     let contactSheets: [ContactSheet]
     let onAddToContactSheet: (UUID, URL) -> Void
+    let onArchive: (ImageFile) -> Void
 
     var body: some View {
         GeometryReader { geometry in
@@ -238,7 +244,8 @@ struct ImageGridView: View {
                                 onDoubleClickImage: onDoubleClickImage,
                                 onRename: onRename,
                                 contactSheets: contactSheets,
-                                onAddToContactSheet: onAddToContactSheet
+                                onAddToContactSheet: onAddToContactSheet,
+                                onArchive: onArchive
                             )
                             .id(file.id)
                             .onAppear {
@@ -317,6 +324,7 @@ struct GridCell: View {
     let onRename: (URL, String) -> Void
     let contactSheets: [ContactSheet]
     let onAddToContactSheet: (UUID, URL) -> Void
+    let onArchive: (ImageFile) -> Void
     @State private var isHovered = false
 
     var body: some View {
@@ -347,17 +355,12 @@ struct GridCell: View {
         .onDrag {
             imageFileProvider(for: file.url)
         }
-        .contextMenu {
-            if !contactSheets.isEmpty {
-                Menu("Add to Contact Sheet") {
-                    ForEach(contactSheets) { sheet in
-                        Button(sheet.name) {
-                            onAddToContactSheet(sheet.id, file.url)
-                        }
-                    }
-                }
-            }
-        }
+        .imageLibraryContextMenu(
+            file: file,
+            contactSheets: contactSheets,
+            onAddToContactSheet: onAddToContactSheet,
+            onArchive: onArchive
+        )
     }
 }
 
@@ -370,6 +373,9 @@ struct ImageListView: View {
     let onDoubleClickImage: (UUID) -> Void
     @Binding var scrollToID: UUID?
     let onRename: (URL, String) -> Void
+    let contactSheets: [ContactSheet]
+    let onAddToContactSheet: (UUID, URL) -> Void
+    let onArchive: (ImageFile) -> Void
 
     var body: some View {
         ScrollViewReader { proxy in
@@ -381,7 +387,10 @@ struct ImageListView: View {
                             isSelected: selectedImageFileIDs.contains(file.id),
                             onSelectImage: onSelectImage,
                             onDoubleClickImage: onDoubleClickImage,
-                            onRename: onRename
+                            onRename: onRename,
+                            contactSheets: contactSheets,
+                            onAddToContactSheet: onAddToContactSheet,
+                            onArchive: onArchive
                         )
                         .id(file.id)
                         .onAppear {
@@ -417,6 +426,9 @@ struct ImageListRow: View {
     let onSelectImage: (UUID) -> Void
     let onDoubleClickImage: (UUID) -> Void
     let onRename: (URL, String) -> Void
+    let contactSheets: [ContactSheet]
+    let onAddToContactSheet: (UUID, URL) -> Void
+    let onArchive: (ImageFile) -> Void
     @State private var isHovered = false
 
     var body: some View {
@@ -457,6 +469,12 @@ struct ImageListRow: View {
         .onDrag {
             imageFileProvider(for: file.url)
         }
+        .imageLibraryContextMenu(
+            file: file,
+            contactSheets: contactSheets,
+            onAddToContactSheet: onAddToContactSheet,
+            onArchive: onArchive
+        )
         .simultaneousGesture(
             TapGesture(count: 1)
                 .onEnded { _ in onSelectImage(file.id) }
@@ -465,6 +483,32 @@ struct ImageListRow: View {
             TapGesture(count: 2)
                 .onEnded { _ in onDoubleClickImage(file.id) }
         )
+    }
+}
+
+private extension View {
+    @ViewBuilder
+    func imageLibraryContextMenu(
+        file: ImageFile,
+        contactSheets: [ContactSheet],
+        onAddToContactSheet: @escaping (UUID, URL) -> Void,
+        onArchive: @escaping (ImageFile) -> Void
+    ) -> some View {
+        contextMenu {
+            if !contactSheets.isEmpty {
+                Menu("Add to Contact Sheet") {
+                    ForEach(contactSheets) { sheet in
+                        Button(sheet.name) {
+                            onAddToContactSheet(sheet.id, file.url)
+                        }
+                    }
+                }
+            }
+
+            Button("Move to Archive") {
+                onArchive(file)
+            }
+        }
     }
 }
 

--- a/Microfiche/Views/SettingsView.swift
+++ b/Microfiche/Views/SettingsView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct SettingsView: View {
     @ObservedObject private var preferences = UserPreferences.shared
+    @ObservedObject private var archiveFolder = ArchiveFolderStore.shared
 
     var body: some View {
         Form {
@@ -24,7 +25,7 @@ struct SettingsView: View {
 
                     Spacer(minLength: 0)
 
-                    Text(statusLabel)
+                    Text(onboardingStatusLabel)
                         .font(.system(size: 12))
                         .foregroundStyle(.secondary)
                 }
@@ -33,13 +34,44 @@ struct SettingsView: View {
             } footer: {
                 Text("Turn this off to skip the welcome sequence while testing. Use Replay to walk through it again.")
             }
+
+            Section {
+                HStack {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(archiveFolder.displayName ?? "No archive folder")
+                            .font(.system(size: 13, weight: .medium))
+                        Text(archiveStatusLabel)
+                            .font(.system(size: 11))
+                            .foregroundStyle(.secondary)
+                    }
+
+                    Spacer(minLength: 12)
+
+                    Button(archiveFolder.hasConfiguredFolder ? "Change…" : "Choose…") {
+                        _ = archiveFolder.chooseFolder()
+                    }
+
+                    if archiveFolder.hasConfiguredFolder {
+                        Button("Clear", role: .destructive) {
+                            archiveFolder.clearFolder()
+                        }
+                    }
+                }
+            } header: {
+                Text("Archive")
+            } footer: {
+                Text("Move to Archive relocates selected images into this folder without copying them into the library.")
+            }
         }
         .formStyle(.grouped)
         .frame(width: 420)
         .padding()
+        .onAppear {
+            archiveFolder.refresh()
+        }
     }
 
-    private var statusLabel: String {
+    private var onboardingStatusLabel: String {
         if !preferences.isOnboardingEnabled {
             return "Disabled"
         }
@@ -47,6 +79,16 @@ struct SettingsView: View {
             return "Showing now"
         }
         return preferences.hasCompletedOnboarding ? "Completed" : "Pending"
+    }
+
+    private var archiveStatusLabel: String {
+        if !archiveFolder.hasConfiguredFolder {
+            return "Choose a folder to enable Move to Archive"
+        }
+        if archiveFolder.isAvailable {
+            return "Ready"
+        }
+        return "Unavailable — reconnect or choose a new folder"
     }
 }
 

--- a/MicroficheTests/MicroficheTests.swift
+++ b/MicroficheTests/MicroficheTests.swift
@@ -510,4 +510,76 @@ final class MicroficheTests: XCTestCase {
         XCTAssertTrue(steps.allSatisfy { !$0.title.isEmpty && !$0.message.isEmpty && !$0.symbolName.isEmpty })
     }
 
+    func testFileArchiverUniqueDestinationAvoidsCollisions() throws {
+        let fileManager = FileManager.default
+        let root = fileManager.temporaryDirectory
+            .appendingPathComponent("microfiche-archive-\(UUID().uuidString)", isDirectory: true)
+        let directory = root.appendingPathComponent("archive", isDirectory: true)
+        try fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? fileManager.removeItem(at: root) }
+
+        let source = root.appendingPathComponent("photo.png")
+        try Data([0x89, 0x50, 0x4E, 0x47]).write(to: source)
+
+        let first = FileArchiver.uniqueDestination(for: source, in: directory, fileManager: fileManager)
+        XCTAssertEqual(first.lastPathComponent, "photo.png")
+
+        try Data([0x01]).write(to: first)
+        let second = FileArchiver.uniqueDestination(for: source, in: directory, fileManager: fileManager)
+        XCTAssertEqual(second.lastPathComponent, "photo-1.png")
+
+        try Data([0x02]).write(to: second)
+        let third = FileArchiver.uniqueDestination(for: source, in: directory, fileManager: fileManager)
+        XCTAssertEqual(third.lastPathComponent, "photo-2.png")
+    }
+
+    func testFileArchiverMovesIntoArchiveFolder() throws {
+        let fileManager = FileManager.default
+        let root = fileManager.temporaryDirectory
+            .appendingPathComponent("microfiche-archive-move-\(UUID().uuidString)", isDirectory: true)
+        let library = root.appendingPathComponent("library", isDirectory: true)
+        let archive = root.appendingPathComponent("archive", isDirectory: true)
+        try fileManager.createDirectory(at: library, withIntermediateDirectories: true)
+        try fileManager.createDirectory(at: archive, withIntermediateDirectories: true)
+        defer { try? fileManager.removeItem(at: root) }
+
+        let source = library.appendingPathComponent("keep.png")
+        try Data([0x89, 0x50, 0x4E, 0x47]).write(to: source)
+
+        let destination = try FileArchiver.move(source, intoArchive: archive, fileManager: fileManager)
+        XCTAssertEqual(destination.deletingLastPathComponent(), archive)
+        XCTAssertFalse(fileManager.fileExists(atPath: source.path))
+        XCTAssertTrue(fileManager.fileExists(atPath: destination.path))
+    }
+
+    @MainActor
+    func testArchiveFolderStorePersistsChosenFolder() throws {
+        let suiteName = "microfiche.tests.archive-folder.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let fileManager = FileManager.default
+        let folder = fileManager.temporaryDirectory
+            .appendingPathComponent("microfiche-archive-store-\(UUID().uuidString)", isDirectory: true)
+        try fileManager.createDirectory(at: folder, withIntermediateDirectories: true)
+        defer { try? fileManager.removeItem(at: folder) }
+
+        let store = ArchiveFolderStore(defaults: defaults, fileManager: fileManager)
+        XCTAssertFalse(store.hasConfiguredFolder)
+
+        XCTAssertTrue(store.setFolder(folder))
+        XCTAssertTrue(store.hasConfiguredFolder)
+        XCTAssertTrue(store.isAvailable)
+        XCTAssertEqual(store.displayName, folder.lastPathComponent)
+        XCTAssertEqual(store.resolvedURL()?.path, folder.path)
+
+        let restored = ArchiveFolderStore(defaults: defaults, fileManager: fileManager)
+        XCTAssertTrue(restored.hasConfiguredFolder)
+        XCTAssertEqual(restored.resolvedURL()?.path, folder.path)
+
+        restored.clearFolder()
+        XCTAssertFalse(restored.hasConfiguredFolder)
+        XCTAssertNil(restored.resolvedURL())
+    }
+
 }

--- a/design.md
+++ b/design.md
@@ -121,6 +121,7 @@ Handled by `KeyboardEventHandlingView` when a text field is not first responder.
 | Esc | Detail → quick preview → clear selection (in that order) |
 | Delete | Move selection to Trash (confirm unless bypassed) |
 | ⌘/⇧+Delete | Bypass delete confirmation |
+| ⌘⇧A | Move selection to Archive (prompts for folder if unset) |
 
 Don’t steal keys while the user is editing text.
 
@@ -181,8 +182,9 @@ Disable animations while the grid size slider is dragging. Prefer `MicroficheMot
 
 1. **Images drag as file URLs** from grid and list.
 2. **Contact sheets are drop targets** — Accent border while targeted; accept image file URLs.
-3. **Grid context menu** — “Add to Contact Sheet” when sheets exist. Keep list parity when adding menu actions.
-4. **Destructive actions stay in context menus** — Don’t put Remove/Forget/Delete in the always-visible chrome.
+3. **Grid and list context menus** — “Add to Contact Sheet” when sheets exist, plus “Move to Archive”.
+4. **Archive** — Moves selected originals into a user-chosen folder (Settings → Archive, or prompted on first use). Menu: **File → Move to Archive** (⌘⇧A). Local Microfiche metadata follows the move.
+5. **Destructive actions stay in context menus** — Don’t put Remove/Forget/Delete in the always-visible chrome.
 
 ---
 
@@ -214,11 +216,14 @@ Disable animations while the grid size slider is dragging. Prefer `MicroficheMot
 - Shows once until completed/skipped when **Settings → Onboarding → Show welcome onboarding** is on.
 - Testing: toggle the setting off to suppress; use **Replay Onboarding** or **Help → Replay Welcome Onboarding** to walk through again.
 
+### Archive folder
+- **Files:** `Services/ArchiveFolderStore.swift`, `Services/FileArchiver.swift`, `SettingsView.swift`
+- Security-scoped bookmark for the destination folder; collision-safe rename on move.
+
 ---
 
 ## Future Enhancements
 
 - Propagate Reduce Motion to all `MicroficheMotion` call sites
 - Keyboard focus ring that matches selection chrome
-- List view parity for “Add to Contact Sheet”
 - Retire or wire unused helpers (`microficheToolbarChrome`, `sidebarSelectionBackground`) deliberately


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add **Move to Archive** for selected images (context menu on grid/list, **File → Move to Archive** / ⌘⇧A)
- Persist a security-scoped archive folder bookmark via **Settings → Archive**, prompting on first use if unset
- Relocate originals with collision-safe renaming; local Microfiche metadata follows the move
- Give **list** rows the same **Add to Contact Sheet** context menu as the grid
- Cover archiver destination naming, moves, and folder persistence with unit tests

## Test plan
- [ ] Settings → Archive → Choose a folder; confirm display name and Clear work
- [ ] In grid, context-menu **Move to Archive** on one image and on a multi-selection
- [ ] In list, confirm **Add to Contact Sheet** and **Move to Archive** both appear
- [ ] Use ⌘⇧A with a selection; with no archive folder set, choose one from the prompt
- [ ] Archive a file whose name already exists in the archive folder and confirm `-1` / `-2` renaming
- [ ] Confirm local tags/comments follow the archived file path
- [ ] Run unit tests: `testFileArchiverUniqueDestinationAvoidsCollisions`, `testFileArchiverMovesIntoArchiveFolder`, `testArchiveFolderStorePersistsChosenFolder`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fb12b-b58b-78cd-b543-cb12e3f38837"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fb12b-b58b-78cd-b543-cb12e3f38837"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

