### PR TITLE
Add persistent live library indexing

### DIFF
--- a/Microfiche/ContentView.swift
+++ b/Microfiche/ContentView.swift
@@ -99,7 +99,6 @@ struct ContentView: View {
 
     @State private var selection: Selection?
     @State private var imageFiles: [ImageFile] = []
-    @State private var libraryLoadGeneration = UUID()
     @State private var viewMode: ViewMode = .grid
     @State private var gridThumbnailSize: CGFloat = GridThumbnailSizing.defaultValue
     @State private var liveGridThumbnailSize: CGFloat?
@@ -125,9 +124,8 @@ struct ContentView: View {
     @StateObject private var contactSheetStorage = ContactSheetStorage.shared
     @StateObject private var userPreferences = UserPreferences.shared
     @StateObject private var archiveFolderStore = ArchiveFolderStore.shared
+    @StateObject private var libraryIndex = LibraryIndexStore.shared
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
-
-    let supportedExtensions = ["jpg", "jpeg", "png", "pdf", "svg", "gif", "tiff"]
 
     private var displayedGridThumbnailSize: CGFloat {
         liveGridThumbnailSize ?? gridThumbnailSize
@@ -139,14 +137,12 @@ struct ContentView: View {
                 .onChange(of: selection) { _, newValue in
                     switch newValue {
                     case .all:
-                        loadImages(from: libraryStorage.availableFolderURLs)
+                        refreshIndexedImages()
                         lastSelectedLibraryFolderID = ""
                     case .folder(let id):
-                        let urls = libraryStorage.folder(id: id)?.resolvedURL.map { [$0] } ?? []
-                        loadImages(from: urls)
+                        refreshIndexedImages()
                         lastSelectedLibraryFolderID = id.uuidString
                     case .contactSheet(let id):
-                        libraryLoadGeneration = UUID()
                         imageFiles = contactSheetStorage.getImages(for: id)
                     case .none:
                         imageFiles = []
@@ -157,7 +153,14 @@ struct ContentView: View {
                     libraryPath.removeAll()
                 }
                 .onChange(of: libraryStorage.linkedFolders) {
+                    libraryIndex.configure(folders: libraryStorage.linkedFolders)
                     reloadSelectedLibraryLocation()
+                    Task {
+                        await libraryIndex.reconcileAll()
+                    }
+                }
+                .onChange(of: libraryIndex.revision) {
+                    refreshIndexedImages()
                 }
                 .onChange(of: libraryPath) { oldPath, newPath in
                     if LibraryNavigation.detailImageID(in: oldPath) != nil,
@@ -294,8 +297,10 @@ struct ContentView: View {
         .animation(MicroficheMotion.snap, value: isQuickPreviewPresented)
         .animation(MicroficheMotion.transition, value: userPreferences.isPresentingOnboarding)
         .task {
+            libraryIndex.configure(folders: libraryStorage.linkedFolders)
             restoreLibrarySelection()
             userPreferences.evaluateLaunchPresentation()
+            await libraryIndex.reconcileAll()
         }
     }
 
@@ -550,6 +555,7 @@ struct ContentView: View {
     private func removeFolder(_ id: UUID) {
         if let index = libraryStorage.linkedFolders.firstIndex(where: { $0.id == id }) {
             let wasSelected = (selection == .folder(id))
+            libraryIndex.removeFolder(id: id)
             libraryStorage.removeFolder(id: id)
 
             if wasSelected {
@@ -576,11 +582,8 @@ struct ContentView: View {
 
     private func reloadSelectedLibraryLocation() {
         switch selection {
-        case .all:
-            loadImages(from: libraryStorage.availableFolderURLs)
-        case .folder(let id):
-            let urls = libraryStorage.folder(id: id)?.resolvedURL.map { [$0] } ?? []
-            loadImages(from: urls)
+        case .all, .folder:
+            refreshIndexedImages()
         case .contactSheet, .none:
             break
         }
@@ -600,7 +603,7 @@ struct ContentView: View {
 
     private func handleDropToContactSheet(sheetID: UUID, urls: [URL]) {
         let supportedURLs = urls.filter {
-            supportedExtensions.contains($0.pathExtension.lowercased())
+            SupportedImageExtensions.contains($0)
         }
         _ = contactSheetStorage.addImages(from: supportedURLs, to: sheetID)
 
@@ -610,7 +613,7 @@ struct ContentView: View {
     }
 
     private func handleAddToContactSheet(sheetID: UUID, imageURL: URL) {
-        guard supportedExtensions.contains(imageURL.pathExtension.lowercased()) else { return }
+        guard SupportedImageExtensions.contains(imageURL) else { return }
         _ = contactSheetStorage.addImage(from: imageURL, to: sheetID)
 
         if selection == .contactSheet(sheetID) {
@@ -620,31 +623,30 @@ struct ContentView: View {
 
     // MARK: - Image Loading
 
-    private func loadImages(from folderURLs: [URL]) {
-        let generation = UUID()
-        libraryLoadGeneration = generation
-        imageFiles = []
-
-        DispatchQueue.global(qos: .userInitiated).async {
-            var newImageFiles: [ImageFile] = []
-            let fileManager = FileManager.default
-
-            for folderURL in folderURLs {
-                if let enumerator = fileManager.enumerator(at: folderURL, includingPropertiesForKeys: [.isRegularFileKey], options: [.skipsHiddenFiles, .skipsPackageDescendants]) {
-                    for case let fileURL as URL in enumerator {
-                        if supportedExtensions.contains(fileURL.pathExtension.lowercased()) {
-                            newImageFiles.append(ImageFile(url: fileURL))
-                        }
-                    }
-                }
+    private func refreshIndexedImages() {
+        let folderIDs: [UUID]
+        switch selection {
+        case .all:
+            folderIDs = libraryStorage.linkedFolders.compactMap {
+                $0.isAvailable ? $0.id : nil
             }
+        case .folder(let id):
+            folderIDs = libraryStorage.folder(id: id)?.isAvailable == true ? [id] : []
+        case .contactSheet, .none:
+            return
+        }
 
-            newImageFiles.sort { $0.name.localizedStandardCompare($1.name) == .orderedAscending }
+        let nextFiles = libraryIndex.files(for: folderIDs)
+        let nextIDs = Set(nextFiles.map(\.id))
+        imageFiles = nextFiles
+        selectedImageFileIDs.formIntersection(nextIDs)
 
-            DispatchQueue.main.async {
-                guard self.libraryLoadGeneration == generation else { return }
-                self.imageFiles = newImageFiles
-            }
+        if let focusedImageFileID, !nextIDs.contains(focusedImageFileID) {
+            self.focusedImageFileID = nil
+            isQuickPreviewPresented = false
+        }
+        if let detailImageID, !nextIDs.contains(detailImageID) {
+            libraryPath.removeAll()
         }
     }
 
@@ -748,6 +750,7 @@ struct ContentView: View {
             do {
                 let destination = try FileArchiver.move(file.url, intoArchive: archiveURL)
                 ImageMetadataStore.shared.move(from: file.url, to: destination)
+                libraryIndex.move(from: file.url, to: destination)
                 ImageCache.shared.clearCacheForFile(at: file.url)
                 PreviewImageCache.shared.clearCacheForFile(at: file.url)
                 imageFiles.removeAll { $0.id == file.id }
@@ -811,6 +814,7 @@ struct ContentView: View {
             }
         }
         ImageMetadataStore.shared.remove(for: trashedURLs)
+        libraryIndex.remove(urls: trashedURLs)
         for url in trashedURLs {
             ImageCache.shared.clearCacheForFile(at: url)
             PreviewImageCache.shared.clearCacheForFile(at: url)
@@ -966,6 +970,7 @@ struct ContentView: View {
         do {
             try FileManager.default.moveItem(at: oldURL, to: newURL)
             ImageMetadataStore.shared.move(from: oldURL, to: newURL)
+            libraryIndex.move(from: oldURL, to: newURL)
             ImageCache.shared.clearCacheForFile(at: oldURL)
             PreviewImageCache.shared.clearCacheForFile(at: oldURL)
 

--- a/Microfiche/Models/SupportedImageExtensions.swift
+++ b/Microfiche/Models/SupportedImageExtensions.swift
@@ -1,0 +1,16 @@
+//
+//  SupportedImageExtensions.swift
+//  Microfiche
+//
+
+import Foundation
+
+enum SupportedImageExtensions {
+    static let all: Set<String> = [
+        "jpg", "jpeg", "png", "pdf", "svg", "gif", "tiff"
+    ]
+
+    static func contains(_ url: URL) -> Bool {
+        all.contains(url.pathExtension.lowercased())
+    }
+}

--- a/Microfiche/Services/FolderWatchService.swift
+++ b/Microfiche/Services/FolderWatchService.swift
@@ -1,0 +1,180 @@
+//
+//  FolderWatchService.swift
+//  Microfiche
+//
+
+import CoreServices
+import Foundation
+
+/// Watches linked library roots recursively and coalesces filesystem changes.
+final class FolderWatchService {
+    struct Change: Equatable, Sendable {
+        let folderID: UUID
+        let paths: Set<String>
+        let requiresFullScan: Bool
+    }
+
+    var onChanges: (([Change]) -> Void)?
+
+    private struct Root {
+        let folderID: UUID
+        let path: String
+    }
+
+    private struct PendingChange {
+        var paths: Set<String> = []
+        var requiresFullScan = false
+    }
+
+    private let queue = DispatchQueue(label: "com.microfiche.library-watcher")
+    private var roots: [Root] = []
+    private var stream: FSEventStreamRef?
+    private var pendingChanges: [UUID: PendingChange] = [:]
+    private var deliveryWorkItem: DispatchWorkItem?
+
+    deinit {
+        stop()
+    }
+
+    func setWatchedRoots(_ watchedRoots: [(folderID: UUID, url: URL)]) {
+        let roots = watchedRoots.map {
+            Root(
+                folderID: $0.folderID,
+                path: $0.url.standardizedFileURL.resolvingSymlinksInPath().path
+            )
+        }
+
+        queue.async { [weak self] in
+            self?.replaceRoots(with: roots)
+        }
+    }
+
+    func stop() {
+        queue.sync {
+            stopStream()
+            deliveryWorkItem?.cancel()
+            deliveryWorkItem = nil
+            pendingChanges.removeAll()
+        }
+    }
+
+    private func replaceRoots(with roots: [Root]) {
+        stopStream()
+        deliveryWorkItem?.cancel()
+        deliveryWorkItem = nil
+        self.roots = roots
+        pendingChanges.removeAll()
+
+        guard !roots.isEmpty else { return }
+
+        var context = FSEventStreamContext(
+            version: 0,
+            info: Unmanaged.passUnretained(self).toOpaque(),
+            retain: nil,
+            release: nil,
+            copyDescription: nil
+        )
+        let paths = roots.map(\.path) as CFArray
+        let flags = FSEventStreamCreateFlags(
+            kFSEventStreamCreateFlagUseCFTypes
+                | kFSEventStreamCreateFlagFileEvents
+                | kFSEventStreamCreateFlagWatchRoot
+                | kFSEventStreamCreateFlagNoDefer
+        )
+
+        guard let stream = FSEventStreamCreate(
+            nil,
+            { _, contextInfo, eventCount, eventPaths, eventFlags, _ in
+                guard let contextInfo else { return }
+                let watcher = Unmanaged<FolderWatchService>
+                    .fromOpaque(contextInfo)
+                    .takeUnretainedValue()
+                let paths = unsafeBitCast(eventPaths, to: NSArray.self) as? [String] ?? []
+                watcher.handle(paths: paths, flags: eventFlags, count: eventCount)
+            },
+            &context,
+            paths,
+            FSEventStreamEventId(kFSEventStreamEventIdSinceNow),
+            0.25,
+            flags
+        ) else {
+            return
+        }
+
+        self.stream = stream
+        FSEventStreamSetDispatchQueue(stream, queue)
+        guard FSEventStreamStart(stream) else {
+            FSEventStreamInvalidate(stream)
+            FSEventStreamRelease(stream)
+            self.stream = nil
+            return
+        }
+    }
+
+    private func stopStream() {
+        guard let stream else { return }
+        FSEventStreamStop(stream)
+        FSEventStreamInvalidate(stream)
+        FSEventStreamRelease(stream)
+        self.stream = nil
+    }
+
+    private func handle(
+        paths: [String],
+        flags: UnsafePointer<FSEventStreamEventFlags>,
+        count: Int
+    ) {
+        guard !roots.isEmpty else { return }
+
+        for index in 0..<min(count, paths.count) {
+            let path = URL(fileURLWithPath: paths[index])
+                .standardizedFileURL
+                .resolvingSymlinksInPath()
+                .path
+            let matchingRoots = roots.filter {
+                path == $0.path || path.hasPrefix($0.path + "/")
+            }
+            guard !matchingRoots.isEmpty else {
+                continue
+            }
+
+            let eventFlags = flags[index]
+            let requiresFullScan =
+                eventFlags & FSEventStreamEventFlags(kFSEventStreamEventFlagMustScanSubDirs) != 0
+                || eventFlags & FSEventStreamEventFlags(kFSEventStreamEventFlagUserDropped) != 0
+                || eventFlags & FSEventStreamEventFlags(kFSEventStreamEventFlagKernelDropped) != 0
+                || eventFlags & FSEventStreamEventFlags(kFSEventStreamEventFlagRootChanged) != 0
+                || eventFlags & FSEventStreamEventFlags(kFSEventStreamEventFlagEventIdsWrapped) != 0
+
+            for root in matchingRoots {
+                var pending = pendingChanges[root.folderID] ?? PendingChange()
+                pending.paths.insert(path)
+                pending.requiresFullScan = pending.requiresFullScan || requiresFullScan
+                pendingChanges[root.folderID] = pending
+            }
+        }
+
+        scheduleDelivery()
+    }
+
+    private func scheduleDelivery() {
+        deliveryWorkItem?.cancel()
+        let workItem = DispatchWorkItem { [weak self] in
+            guard let self else { return }
+            let changes = self.pendingChanges.map { folderID, pending in
+                Change(
+                    folderID: folderID,
+                    paths: pending.paths,
+                    requiresFullScan: pending.requiresFullScan
+                )
+            }
+            self.pendingChanges.removeAll()
+            guard !changes.isEmpty else { return }
+            DispatchQueue.main.async { [weak self] in
+                self?.onChanges?(changes)
+            }
+        }
+        deliveryWorkItem = workItem
+        queue.asyncAfter(deadline: .now() + 0.3, execute: workItem)
+    }
+}

--- a/Microfiche/Services/LibraryIndexStore.swift
+++ b/Microfiche/Services/LibraryIndexStore.swift
@@ -1,0 +1,411 @@
+//
+//  LibraryIndexStore.swift
+//  Microfiche
+//
+
+import Combine
+import Foundation
+
+struct LibraryIndexEntry: Codable, Equatable, Sendable {
+    let path: String
+    let modificationDate: Date?
+    let fileSize: Int?
+
+    var imageFile: ImageFile {
+        ImageFile(url: URL(fileURLWithPath: path))
+    }
+}
+
+enum LibraryIndexScanner {
+    static func scan(
+        root: URL,
+        fileManager: FileManager = .default
+    ) -> [LibraryIndexEntry] {
+        var entries: [LibraryIndexEntry] = []
+        let keys: [URLResourceKey] = [
+            .isRegularFileKey,
+            .contentModificationDateKey,
+            .fileSizeKey
+        ]
+        guard let enumerator = fileManager.enumerator(
+            at: root,
+            includingPropertiesForKeys: keys,
+            options: [.skipsHiddenFiles, .skipsPackageDescendants]
+        ) else {
+            return entries
+        }
+
+        for case let fileURL as URL in enumerator {
+            if let entry = entry(for: fileURL, fileManager: fileManager) {
+                entries.append(entry)
+            }
+        }
+        return entries
+    }
+
+    static func applying(
+        changedPaths: Set<String>,
+        to existing: [LibraryIndexEntry],
+        under root: URL,
+        fileManager: FileManager = .default
+    ) -> [LibraryIndexEntry] {
+        let rootPath = normalizedPath(root)
+        var entriesByPath = Dictionary(
+            uniqueKeysWithValues: existing.map { ($0.path, $0) }
+        )
+
+        for rawPath in changedPaths {
+            let changedURL = URL(fileURLWithPath: rawPath)
+                .standardizedFileURL
+                .resolvingSymlinksInPath()
+            let changedPath = changedURL.path
+            guard isWithin(changedPath, rootPath: rootPath) else { continue }
+
+            var isDirectory: ObjCBool = false
+            let exists = fileManager.fileExists(
+                atPath: changedPath,
+                isDirectory: &isDirectory
+            )
+
+            if exists, isDirectory.boolValue {
+                removeEntries(atOrBelow: changedPath, from: &entriesByPath)
+                for entry in scan(root: changedURL, fileManager: fileManager) {
+                    entriesByPath[entry.path] = entry
+                }
+            } else if exists,
+                      let entry = entry(for: changedURL, fileManager: fileManager) {
+                entriesByPath[entry.path] = entry
+            } else {
+                removeEntries(atOrBelow: changedPath, from: &entriesByPath)
+            }
+        }
+
+        return Array(entriesByPath.values)
+    }
+
+    private static func entry(
+        for url: URL,
+        fileManager: FileManager
+    ) -> LibraryIndexEntry? {
+        guard SupportedImageExtensions.contains(url) else { return nil }
+        let keys: Set<URLResourceKey> = [
+            .isRegularFileKey,
+            .contentModificationDateKey,
+            .fileSizeKey
+        ]
+        guard let values = try? url.resourceValues(forKeys: keys),
+              values.isRegularFile == true else {
+            return nil
+        }
+
+        return LibraryIndexEntry(
+            path: normalizedPath(url),
+            modificationDate: values.contentModificationDate,
+            fileSize: values.fileSize
+        )
+    }
+
+    private static func removeEntries(
+        atOrBelow path: String,
+        from entriesByPath: inout [String: LibraryIndexEntry]
+    ) {
+        entriesByPath = entriesByPath.filter {
+            $0.key != path && !$0.key.hasPrefix(path + "/")
+        }
+    }
+
+    private static func normalizedPath(_ url: URL) -> String {
+        url.standardizedFileURL.resolvingSymlinksInPath().path
+    }
+
+    private static func isWithin(_ path: String, rootPath: String) -> Bool {
+        path == rootPath || path.hasPrefix(rootPath + "/")
+    }
+}
+
+@MainActor
+final class LibraryIndexStore: ObservableObject {
+    static let shared = LibraryIndexStore()
+
+    @Published private(set) var revision: UInt64 = 0
+
+    private struct FolderSlice: Codable, Equatable {
+        let folderID: UUID
+        var entries: [LibraryIndexEntry]
+        var lastScannedAt: Date?
+    }
+
+    private struct PersistedIndex: Codable {
+        let version: Int
+        var folders: [FolderSlice]
+    }
+
+    private let fileManager: FileManager
+    private let persistenceURL: URL
+    private let watcher: FolderWatchService?
+    private var slices: [UUID: FolderSlice] = [:]
+    private var availableRoots: [UUID: URL] = [:]
+    private var reconcileGenerations: [UUID: UUID] = [:]
+    private var mutationVersions: [UUID: UInt64] = [:]
+    private var fileSystemChangeTasks: [UUID: Task<Void, Never>] = [:]
+    private var fileSystemChangeGenerations: [UUID: UUID] = [:]
+
+    init(
+        persistenceURL customPersistenceURL: URL? = nil,
+        fileManager: FileManager = .default,
+        watchesFileSystem: Bool = true
+    ) {
+        self.fileManager = fileManager
+        let applicationSupport = fileManager.urls(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask
+        ).first!
+        let directory = applicationSupport.appendingPathComponent(
+            "Microfiche",
+            isDirectory: true
+        )
+        persistenceURL = customPersistenceURL
+            ?? directory.appendingPathComponent("library-index.json")
+        watcher = watchesFileSystem ? FolderWatchService() : nil
+
+        try? fileManager.createDirectory(
+            at: persistenceURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        load()
+
+        watcher?.onChanges = { [weak self] changes in
+            guard let self else { return }
+            Task { @MainActor in
+                self.enqueueFileSystemChanges(changes)
+            }
+        }
+    }
+
+    func configure(folders: [LinkedLibraryFolder]) {
+        let folderIDs = Set(folders.map(\.id))
+        let staleIDs = Set(slices.keys).subtracting(folderIDs)
+        if !staleIDs.isEmpty {
+            staleIDs.forEach {
+                slices.removeValue(forKey: $0)
+                reconcileGenerations.removeValue(forKey: $0)
+                mutationVersions.removeValue(forKey: $0)
+                fileSystemChangeGenerations.removeValue(forKey: $0)
+                fileSystemChangeTasks.removeValue(forKey: $0)?.cancel()
+            }
+            persist()
+            bumpRevision()
+        }
+
+        availableRoots = Dictionary(
+            uniqueKeysWithValues: folders.compactMap { folder in
+                folder.resolvedURL.map { (folder.id, $0) }
+            }
+        )
+        watcher?.setWatchedRoots(
+            availableRoots.map { (folderID: $0.key, url: $0.value) }
+        )
+    }
+
+    func reconcileAll() async {
+        for folderID in availableRoots.keys {
+            await reconcile(folderID: folderID)
+        }
+    }
+
+    func files(for folderIDs: [UUID]) -> [ImageFile] {
+        var seenPaths = Set<String>()
+        return folderIDs
+            .flatMap { slices[$0]?.entries ?? [] }
+            .filter { seenPaths.insert($0.path).inserted }
+            .map(\.imageFile)
+            .sorted {
+                let result = $0.name.localizedStandardCompare($1.name)
+                return result == .orderedSame
+                    ? $0.url.path < $1.url.path
+                    : result == .orderedAscending
+            }
+    }
+
+    func reconcile(folderID: UUID) async {
+        guard let root = availableRoots[folderID] else { return }
+        let generation = UUID()
+        let mutationVersion = mutationVersions[folderID, default: 0]
+        reconcileGenerations[folderID] = generation
+
+        let entries = await Task.detached(priority: .userInitiated) {
+            LibraryIndexScanner.scan(root: root)
+        }.value
+
+        guard reconcileGenerations[folderID] == generation,
+              mutationVersions[folderID, default: 0] == mutationVersion,
+              availableRoots[folderID] == root else {
+            return
+        }
+        apply(entries: entries, to: folderID, scannedAt: Date())
+    }
+
+    func remove(urls: [URL]) {
+        let paths = Set(urls.map { ImageIdentity.normalizedPath(for: $0) })
+        var didChange = false
+        for folderID in Array(slices.keys) {
+            let oldCount = slices[folderID]?.entries.count ?? 0
+            slices[folderID]?.entries.removeAll { paths.contains($0.path) }
+            if slices[folderID]?.entries.count != oldCount {
+                invalidateInFlightReconcile(for: folderID)
+                didChange = true
+            }
+        }
+        if didChange {
+            persist()
+            bumpRevision()
+        }
+    }
+
+    func move(from oldURL: URL, to newURL: URL) {
+        let oldPath = ImageIdentity.normalizedPath(for: oldURL)
+        var didChange = false
+        for folderID in Array(slices.keys) {
+            guard let existing = slices[folderID]?.entries,
+                  existing.contains(where: { $0.path == oldPath }) else {
+                continue
+            }
+            var updated = existing.filter { $0.path != oldPath }
+            if let root = availableRoots[folderID] {
+                updated = LibraryIndexScanner.applying(
+                    changedPaths: [newURL.path],
+                    to: updated,
+                    under: root,
+                    fileManager: fileManager
+                )
+            }
+            slices[folderID]?.entries = updated
+            invalidateInFlightReconcile(for: folderID)
+            didChange = true
+        }
+        guard didChange else { return }
+        persist()
+        bumpRevision()
+    }
+
+    func removeFolder(id: UUID) {
+        availableRoots.removeValue(forKey: id)
+        reconcileGenerations.removeValue(forKey: id)
+        mutationVersions.removeValue(forKey: id)
+        fileSystemChangeGenerations.removeValue(forKey: id)
+        fileSystemChangeTasks.removeValue(forKey: id)?.cancel()
+        guard slices.removeValue(forKey: id) != nil else { return }
+        persist()
+        bumpRevision()
+    }
+
+    private func enqueueFileSystemChanges(_ changes: [FolderWatchService.Change]) {
+        for change in changes {
+            guard availableRoots[change.folderID] != nil else { continue }
+            reconcileGenerations[change.folderID] = UUID()
+            let previousTask = fileSystemChangeTasks[change.folderID]
+            let taskGeneration = UUID()
+            fileSystemChangeGenerations[change.folderID] = taskGeneration
+            let task = Task { @MainActor [weak self] in
+                _ = await previousTask?.value
+                guard !Task.isCancelled else { return }
+                await self?.applyFileSystemChange(change)
+                guard self?.fileSystemChangeGenerations[change.folderID]
+                    == taskGeneration else {
+                    return
+                }
+                self?.fileSystemChangeTasks.removeValue(forKey: change.folderID)
+                self?.fileSystemChangeGenerations.removeValue(forKey: change.folderID)
+            }
+            fileSystemChangeTasks[change.folderID] = task
+        }
+    }
+
+    private func applyFileSystemChange(
+        _ change: FolderWatchService.Change
+    ) async {
+        guard let root = availableRoots[change.folderID] else { return }
+        if change.requiresFullScan
+            || slices[change.folderID]?.lastScannedAt == nil {
+            await reconcile(folderID: change.folderID)
+            return
+        }
+
+        while !Task.isCancelled {
+            let mutationVersion = mutationVersions[change.folderID, default: 0]
+            let existing = slices[change.folderID]?.entries ?? []
+            let entries = await Task.detached(priority: .utility) {
+                LibraryIndexScanner.applying(
+                    changedPaths: change.paths,
+                    to: existing,
+                    under: root
+                )
+            }.value
+            guard availableRoots[change.folderID] == root else { return }
+            guard mutationVersions[change.folderID, default: 0] == mutationVersion else {
+                continue
+            }
+            apply(entries: entries, to: change.folderID, scannedAt: nil)
+            mutationVersions[change.folderID, default: 0] &+= 1
+            return
+        }
+    }
+
+    private func invalidateInFlightReconcile(for folderID: UUID) {
+        reconcileGenerations[folderID] = UUID()
+        mutationVersions[folderID, default: 0] &+= 1
+    }
+
+    private func apply(
+        entries: [LibraryIndexEntry],
+        to folderID: UUID,
+        scannedAt: Date?
+    ) {
+        let normalizedEntries = entries.sorted { $0.path < $1.path }
+        let existing = slices[folderID]
+        let next = FolderSlice(
+            folderID: folderID,
+            entries: normalizedEntries,
+            lastScannedAt: scannedAt ?? existing?.lastScannedAt
+        )
+        guard next != existing else { return }
+        slices[folderID] = next
+        persist()
+        bumpRevision()
+    }
+
+    private func bumpRevision() {
+        revision &+= 1
+    }
+
+    private func persist() {
+        do {
+            let state = PersistedIndex(
+                version: 1,
+                folders: slices.values.sorted {
+                    $0.folderID.uuidString < $1.folderID.uuidString
+                }
+            )
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+            try encoder.encode(state).write(to: persistenceURL, options: .atomic)
+        } catch {
+            print("Unable to save library index: \(error)")
+        }
+    }
+
+    private func load() {
+        guard fileManager.fileExists(atPath: persistenceURL.path) else { return }
+        do {
+            let data = try Data(contentsOf: persistenceURL)
+            let state = try JSONDecoder().decode(PersistedIndex.self, from: data)
+            guard state.version == 1 else { return }
+            slices = Dictionary(
+                uniqueKeysWithValues: state.folders.map { ($0.folderID, $0) }
+            )
+        } catch {
+            print("Unable to load library index: \(error)")
+            slices = [:]
+        }
+    }
+}

--- a/MicroficheTests/MicroficheTests.swift
+++ b/MicroficheTests/MicroficheTests.swift
@@ -266,6 +266,135 @@ final class MicroficheTests: XCTestCase {
         }
     }
 
+    @MainActor
+    func testLibraryIndexLoadsCachedEntriesBeforeReconcile() async throws {
+        let fileManager = FileManager.default
+        let root = fileManager.temporaryDirectory
+            .appendingPathComponent("microfiche-index-cache-\(UUID().uuidString)")
+        let photos = root.appendingPathComponent("Photos", isDirectory: true)
+        let persistenceURL = root.appendingPathComponent("library-index.json")
+        let imageURL = photos.appendingPathComponent("cached.jpg")
+        try fileManager.createDirectory(at: photos, withIntermediateDirectories: true)
+        try Data("image".utf8).write(to: imageURL)
+        defer { try? fileManager.removeItem(at: root) }
+
+        let folder = makeLinkedFolder(url: photos)
+        let store = LibraryIndexStore(
+            persistenceURL: persistenceURL,
+            watchesFileSystem: false
+        )
+        store.configure(folders: [folder])
+        await store.reconcile(folderID: folder.id)
+        XCTAssertEqual(store.files(for: [folder.id]).map(\.url), [imageURL])
+
+        try fileManager.removeItem(at: imageURL)
+        let restored = LibraryIndexStore(
+            persistenceURL: persistenceURL,
+            watchesFileSystem: false
+        )
+        XCTAssertEqual(restored.files(for: [folder.id]).map(\.name), ["cached.jpg"])
+    }
+
+    @MainActor
+    func testLibraryIndexReconcileAddsRemovesAndFiltersFiles() async throws {
+        let fileManager = FileManager.default
+        let root = fileManager.temporaryDirectory
+            .appendingPathComponent("microfiche-index-reconcile-\(UUID().uuidString)")
+        let photos = root.appendingPathComponent("Photos", isDirectory: true)
+        let persistenceURL = root.appendingPathComponent("library-index.json")
+        let firstImage = photos.appendingPathComponent("one.jpg")
+        let ignoredFile = photos.appendingPathComponent("notes.txt")
+        try fileManager.createDirectory(at: photos, withIntermediateDirectories: true)
+        try Data("one".utf8).write(to: firstImage)
+        try Data("ignored".utf8).write(to: ignoredFile)
+        defer { try? fileManager.removeItem(at: root) }
+
+        let folder = makeLinkedFolder(url: photos)
+        let store = LibraryIndexStore(
+            persistenceURL: persistenceURL,
+            watchesFileSystem: false
+        )
+        store.configure(folders: [folder])
+        await store.reconcile(folderID: folder.id)
+        XCTAssertEqual(store.files(for: [folder.id]).map(\.name), ["one.jpg"])
+
+        try fileManager.removeItem(at: firstImage)
+        let secondImage = photos.appendingPathComponent("two.png")
+        try Data("two".utf8).write(to: secondImage)
+        await store.reconcile(folderID: folder.id)
+
+        XCTAssertEqual(store.files(for: [folder.id]).map(\.name), ["two.png"])
+    }
+
+    func testLibraryIndexScannerAppliesChangedSubtreeIncrementally() throws {
+        let fileManager = FileManager.default
+        let root = fileManager.temporaryDirectory
+            .appendingPathComponent("microfiche-index-delta-\(UUID().uuidString)")
+        let nested = root.appendingPathComponent("Nested", isDirectory: true)
+        let oldImage = nested.appendingPathComponent("old.jpg")
+        try fileManager.createDirectory(at: nested, withIntermediateDirectories: true)
+        try Data("old".utf8).write(to: oldImage)
+        defer { try? fileManager.removeItem(at: root) }
+
+        let initial = LibraryIndexScanner.scan(root: root)
+        XCTAssertEqual(initial.map(\.path), [oldImage.path])
+
+        try fileManager.removeItem(at: oldImage)
+        let newImage = nested.appendingPathComponent("new.png")
+        try Data("new".utf8).write(to: newImage)
+        let updated = LibraryIndexScanner.applying(
+            changedPaths: [nested.path],
+            to: initial,
+            under: root
+        )
+
+        XCTAssertEqual(updated.map(\.path), [newImage.path])
+    }
+
+    @MainActor
+    func testLibraryIndexLocalRenameUpdatesAndPersistsEntry() async throws {
+        let fileManager = FileManager.default
+        let root = fileManager.temporaryDirectory
+            .appendingPathComponent("microfiche-index-rename-\(UUID().uuidString)")
+        let photos = root.appendingPathComponent("Photos", isDirectory: true)
+        let persistenceURL = root.appendingPathComponent("library-index.json")
+        let oldURL = photos.appendingPathComponent("before.jpg")
+        let newURL = photos.appendingPathComponent("after.jpg")
+        try fileManager.createDirectory(at: photos, withIntermediateDirectories: true)
+        try Data("image".utf8).write(to: oldURL)
+        defer { try? fileManager.removeItem(at: root) }
+
+        let folder = makeLinkedFolder(url: photos)
+        let store = LibraryIndexStore(
+            persistenceURL: persistenceURL,
+            watchesFileSystem: false
+        )
+        store.configure(folders: [folder])
+        await store.reconcile(folderID: folder.id)
+        try fileManager.moveItem(at: oldURL, to: newURL)
+        store.move(from: oldURL, to: newURL)
+
+        XCTAssertEqual(store.files(for: [folder.id]).map(\.url), [newURL])
+        let restored = LibraryIndexStore(
+            persistenceURL: persistenceURL,
+            watchesFileSystem: false
+        )
+        XCTAssertEqual(restored.files(for: [folder.id]).map(\.url), [newURL])
+    }
+
+    private func makeLinkedFolder(url: URL) -> LinkedLibraryFolder {
+        LinkedLibraryFolder(
+            id: UUID(),
+            name: url.lastPathComponent,
+            originalPath: url.path,
+            volumeIdentifier: nil,
+            volumeName: nil,
+            isExternal: false,
+            addedAt: .now,
+            resolvedURL: url
+        )
+    }
+
     func testRememberedExternalVolumePersistsConnectionMetadata() throws {
         let volume = RememberedExternalVolume(
             id: "uuid:test-drive",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- cache linked-folder image indexes in Application Support for immediate library restoration
- reconcile indexes in the background and update changed subtrees from debounced FSEvents
- keep the index synchronized with in-app rename, archive, trash, and folder removal operations
- centralize supported image extensions and add deterministic index regression tests

## Verification
- `git diff --check` passed
- macOS build and XCTest execution pending; this Linux cloud environment does not provide Xcode

## Affected states
- cached and first-time folder load
- all-folders and single-folder selection
- external create, delete, rename, directory, and dropped-event reconciliation
- local rename, archive, trash, and linked-folder removal
- nested linked folders and unavailable folders
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fbe8a-b08a-7e15-b5f8-fd6a4c901136?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fbe8a-b08a-7e15-b5f8-fd6a4c901136&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

