### PR TITLE
PCD-30: Export and share contact sheets

### DIFF
--- a/Microfiche/ContentView.swift
+++ b/Microfiche/ContentView.swift
@@ -87,6 +87,13 @@ enum ImageNavigation {
     }
 }
 
+private struct ContactSheetExportPresentation: Identifiable {
+    let contactSheet: ContactSheet
+    let items: [ContactSheetExportItem]
+
+    var id: UUID { contactSheet.id }
+}
+
 // MARK: - Content View
 
 struct ContentView: View {
@@ -116,6 +123,7 @@ struct ContentView: View {
     @State private var scrollToID: UUID?
     @State private var gridColumnCount: Int = 1
     @State private var libraryPath: [LibraryRoute] = []
+    @State private var contactSheetExportPresentation: ContactSheetExportPresentation?
     @AppStorage("libraryMetadataInspectorPresented") private var isMetadataInspectorPresented = false
     @AppStorage("detailMetadataPresented") private var isDetailMetadataPresented = true
     @AppStorage("librarySidebarCollapsed") private var isLibrarySidebarCollapsed = false
@@ -297,6 +305,12 @@ struct ContentView: View {
             restoreLibrarySelection()
             userPreferences.evaluateLaunchPresentation()
         }
+        .sheet(item: $contactSheetExportPresentation) { presentation in
+            ContactSheetExportView(
+                contactSheet: presentation.contactSheet,
+                items: presentation.items
+            )
+        }
     }
 
     private var libraryContainer: AnyView {
@@ -327,6 +341,7 @@ struct ContentView: View {
                             selection = .all
                         }
                     },
+                    onExportContactSheet: presentContactSheetExport,
                     onDropToContactSheet: { sheetID, urls in
                         handleDropToContactSheet(sheetID: sheetID, urls: urls)
                     }
@@ -428,6 +443,20 @@ struct ContentView: View {
                 .help(isMetadataInspectorPresented ? "Hide Info" : "Show Info")
             }
             .hideSharedBackgroundIfAvailable()
+
+            if let activeContactSheet {
+                ToolbarItem {
+                    Button {
+                        presentContactSheetExport(sheetID: activeContactSheet.id)
+                    } label: {
+                        Image(systemName: "doc.badge.arrow.up")
+                    }
+                    .help("Export Contact Sheet")
+                    .accessibilityLabel("Export \(activeContactSheet.name)")
+                    .accessibilityIdentifier("export-contact-sheet")
+                }
+                .hideSharedBackgroundIfAvailable()
+            }
         }
     }
 
@@ -597,6 +626,47 @@ struct ContentView: View {
     }
 
     // MARK: - Contact Sheets
+
+    private func presentContactSheetExport(sheetID: UUID) {
+        guard let contactSheet = contactSheetStorage.contactSheets.first(where: {
+            $0.id == sheetID
+        }) else { return }
+
+        let records = contactSheetStorage.getImageRecords(for: sheetID)
+        let items = records.map(makeContactSheetExportItem)
+        contactSheetExportPresentation = ContactSheetExportPresentation(
+            contactSheet: contactSheet,
+            items: items
+        )
+    }
+
+    private func makeContactSheetExportItem(
+        from record: ContactSheetImage
+    ) -> ContactSheetExportItem {
+        let fileManager = FileManager.default
+        let originalExists = fileManager.fileExists(atPath: record.originalURL.path)
+        let storedExists = fileManager.fileExists(atPath: record.storedURL.path)
+        let imageURL = storedExists
+            ? record.storedURL
+            : (originalExists ? record.originalURL : record.storedURL)
+        let metadataURL = originalExists ? record.originalURL : record.storedURL
+
+        let native = NativeFileMetadataService.load(from: metadataURL)
+        var local = ImageMetadataStore.shared.metadata(for: record.originalURL)
+        if local.isEmpty {
+            local = ImageMetadataStore.shared.metadata(for: record.storedURL)
+        }
+
+        return ContactSheetExportItem(
+            id: record.id,
+            fileName: record.fileName,
+            imageURL: imageURL,
+            finderLabel: native.label == .none ? nil : native.label.displayName,
+            tags: native.tagNames.isEmpty ? local.tags : native.tagNames,
+            comments: native.comment.isEmpty ? local.comments : native.comment,
+            source: local.whereFrom
+        )
+    }
 
     private func handleDropToContactSheet(sheetID: UUID, urls: [URL]) {
         let supportedURLs = urls.filter {

--- a/Microfiche/Services/ContactSheetPDFExporter.swift
+++ b/Microfiche/Services/ContactSheetPDFExporter.swift
@@ -1,0 +1,592 @@
+//
+//  ContactSheetPDFExporter.swift
+//  Microfiche
+//
+//  Deterministic pagination and native PDF rendering for contact sheets.
+//
+
+import AppKit
+import Foundation
+import PDFKit
+
+enum ContactSheetPaperSize: String, CaseIterable, Identifiable, Sendable {
+    case letter = "Letter"
+    case a4 = "A4"
+
+    var id: String { rawValue }
+
+    var portraitSize: CGSize {
+        switch self {
+        case .letter:
+            CGSize(width: 612, height: 792)
+        case .a4:
+            CGSize(width: 595.28, height: 841.89)
+        }
+    }
+}
+
+enum ContactSheetPageOrientation: String, CaseIterable, Identifiable, Sendable {
+    case portrait = "Portrait"
+    case landscape = "Landscape"
+
+    var id: String { rawValue }
+}
+
+struct ContactSheetCaptionOptions: Equatable, Hashable, Sendable {
+    var includesFilename = true
+    var includesFinderLabel = false
+    var includesTags = false
+    var includesComments = false
+    var includesSource = false
+
+    var maximumLineCount: Int {
+        [
+            includesFilename,
+            includesFinderLabel,
+            includesTags,
+            includesComments,
+            includesSource
+        ].filter { $0 }.count
+    }
+}
+
+struct ContactSheetExportOptions: Equatable, Hashable, Sendable {
+    var paperSize: ContactSheetPaperSize = .letter
+    var orientation: ContactSheetPageOrientation = .portrait
+    var margin: CGFloat = 36
+    var columns: Int = 4
+    var captions = ContactSheetCaptionOptions()
+
+    var pageSize: CGSize {
+        let portrait = paperSize.portraitSize
+        switch orientation {
+        case .portrait:
+            return portrait
+        case .landscape:
+            return CGSize(width: portrait.height, height: portrait.width)
+        }
+    }
+
+    var normalized: ContactSheetExportOptions {
+        var copy = self
+        copy.margin = min(max(copy.margin, 24), 72)
+        copy.columns = min(max(copy.columns, 2), 6)
+        return copy
+    }
+}
+
+struct ContactSheetExportItem: Equatable, Hashable, Sendable {
+    let id: UUID
+    let fileName: String
+    let imageURL: URL
+    let finderLabel: String?
+    let tags: [String]
+    let comments: String
+    let source: String
+
+    func captionLines(using options: ContactSheetCaptionOptions) -> [String] {
+        var lines: [String] = []
+        if options.includesFilename {
+            lines.append(fileName)
+        }
+        if options.includesFinderLabel, let finderLabel, !finderLabel.isEmpty {
+            lines.append("Label: \(finderLabel)")
+        }
+        if options.includesTags, !tags.isEmpty {
+            lines.append("Tags: \(tags.joined(separator: ", "))")
+        }
+        if options.includesComments {
+            let normalized = Self.singleLine(comments)
+            if !normalized.isEmpty {
+                lines.append("Comments: \(normalized)")
+            }
+        }
+        if options.includesSource {
+            let normalized = Self.singleLine(source)
+            if !normalized.isEmpty {
+                lines.append("Source: \(normalized)")
+            }
+        }
+        return lines
+    }
+
+    private static func singleLine(_ value: String) -> String {
+        value
+            .components(separatedBy: .whitespacesAndNewlines)
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
+    }
+}
+
+struct ContactSheetPDFLayout: Equatable, Sendable {
+    static let itemSpacing: CGFloat = 12
+    static let headerHeight: CGFloat = 42
+    static let footerHeight: CGFloat = 18
+    static let captionLineHeight: CGFloat = 12
+
+    let pageSize: CGSize
+    let contentRect: CGRect
+    let columns: Int
+    let rowsPerPage: Int
+    let itemsPerPage: Int
+    let pageCount: Int
+    let cellSize: CGSize
+    let imageHeight: CGFloat
+    let captionHeight: CGFloat
+
+    init(itemCount: Int, options rawOptions: ContactSheetExportOptions) {
+        let options = rawOptions.normalized
+        pageSize = options.pageSize
+        columns = options.columns
+
+        let contentWidth = max(1, pageSize.width - (options.margin * 2))
+        let contentHeight = max(
+            1,
+            pageSize.height
+                - (options.margin * 2)
+                - Self.headerHeight
+                - Self.footerHeight
+        )
+        contentRect = CGRect(
+            x: options.margin,
+            y: options.margin + Self.footerHeight,
+            width: contentWidth,
+            height: contentHeight
+        )
+
+        let horizontalSpacing = CGFloat(max(0, columns - 1)) * Self.itemSpacing
+        let cellWidth = max(1, (contentWidth - horizontalSpacing) / CGFloat(columns))
+        captionHeight = options.captions.maximumLineCount == 0
+            ? 0
+            : CGFloat(options.captions.maximumLineCount) * Self.captionLineHeight + 8
+
+        let desiredImageHeight = cellWidth * 0.68
+        let desiredCellHeight = max(48, desiredImageHeight + captionHeight)
+        let rowEstimate = Int(
+            floor((contentHeight + Self.itemSpacing) / (desiredCellHeight + Self.itemSpacing))
+        )
+        rowsPerPage = max(1, rowEstimate)
+        itemsPerPage = max(1, columns * rowsPerPage)
+        pageCount = max(1, Int(ceil(Double(itemCount) / Double(itemsPerPage))))
+
+        let verticalSpacing = CGFloat(max(0, rowsPerPage - 1)) * Self.itemSpacing
+        let cellHeight = max(1, (contentHeight - verticalSpacing) / CGFloat(rowsPerPage))
+        cellSize = CGSize(width: cellWidth, height: cellHeight)
+        imageHeight = max(24, cellHeight - captionHeight)
+    }
+
+    func itemRect(at indexOnPage: Int) -> CGRect {
+        let column = indexOnPage % columns
+        let row = indexOnPage / columns
+        let x = contentRect.minX + CGFloat(column) * (cellSize.width + Self.itemSpacing)
+        let y = contentRect.maxY
+            - CGFloat(row + 1) * cellSize.height
+            - CGFloat(row) * Self.itemSpacing
+        return CGRect(x: x, y: y, width: cellSize.width, height: cellSize.height)
+    }
+}
+
+struct ContactSheetPDFExport: Equatable, Sendable {
+    let data: Data
+    let layout: ContactSheetPDFLayout
+    let unavailableImageNames: [String]
+}
+
+enum ContactSheetPDFExportError: LocalizedError, Equatable, Sendable {
+    case unableToCreateConsumer
+    case unableToCreateContext
+
+    var errorDescription: String? {
+        switch self {
+        case .unableToCreateConsumer:
+            "The PDF data stream could not be created."
+        case .unableToCreateContext:
+            "The PDF drawing context could not be created."
+        }
+    }
+}
+
+struct ContactSheetExportPreviewState: Equatable, Sendable {
+    enum Phase: Equatable, Sendable {
+        case idle
+        case loading
+        case ready(ContactSheetPDFExport)
+        case failed(String)
+    }
+
+    private(set) var phase: Phase = .idle
+    private var activeRequestID: UUID?
+
+    @discardableResult
+    mutating func beginLoading() -> UUID {
+        let requestID = UUID()
+        activeRequestID = requestID
+        phase = .loading
+        return requestID
+    }
+
+    @discardableResult
+    mutating func finish(
+        _ result: Result<ContactSheetPDFExport, ContactSheetPDFExportError>,
+        requestID: UUID
+    ) -> Bool {
+        guard activeRequestID == requestID else { return false }
+        activeRequestID = nil
+        switch result {
+        case .success(let export):
+            phase = .ready(export)
+        case .failure(let error):
+            phase = .failed(error.localizedDescription)
+        }
+        return true
+    }
+
+    @discardableResult
+    mutating func cancel(requestID: UUID) -> Bool {
+        guard activeRequestID == requestID else { return false }
+        activeRequestID = nil
+        phase = .idle
+        return true
+    }
+}
+
+enum ContactSheetPDFExporter {
+    private static let darkText = NSColor(calibratedWhite: 0.13, alpha: 1)
+    private static let secondaryText = NSColor(calibratedWhite: 0.42, alpha: 1)
+    private static let tileBackground = NSColor(calibratedWhite: 0.96, alpha: 1)
+    private static let tileBorder = NSColor(calibratedWhite: 0.86, alpha: 1)
+
+    static func render(
+        title: String,
+        items: [ContactSheetExportItem],
+        options rawOptions: ContactSheetExportOptions
+    ) throws -> ContactSheetPDFExport {
+        let options = rawOptions.normalized
+        let layout = ContactSheetPDFLayout(itemCount: items.count, options: options)
+        let mutableData = NSMutableData()
+        guard let consumer = CGDataConsumer(data: mutableData as CFMutableData) else {
+            throw ContactSheetPDFExportError.unableToCreateConsumer
+        }
+
+        var mediaBox = CGRect(origin: .zero, size: layout.pageSize)
+        guard let context = CGContext(consumer: consumer, mediaBox: &mediaBox, nil) else {
+            throw ContactSheetPDFExportError.unableToCreateContext
+        }
+
+        var unavailableNames: [String] = []
+        for pageIndex in 0..<layout.pageCount {
+            context.beginPDFPage(nil)
+            drawPageBackground(in: context, pageSize: layout.pageSize)
+            drawHeader(
+                title: title,
+                itemCount: items.count,
+                pageIndex: pageIndex,
+                pageCount: layout.pageCount,
+                options: options,
+                in: context,
+                pageSize: layout.pageSize
+            )
+
+            let startIndex = pageIndex * layout.itemsPerPage
+            let endIndex = min(items.count, startIndex + layout.itemsPerPage)
+            if startIndex < endIndex {
+                for itemIndex in startIndex..<endIndex {
+                    let item = items[itemIndex]
+                    let indexOnPage = itemIndex - startIndex
+                    let isAvailable = draw(
+                        item: item,
+                        in: layout.itemRect(at: indexOnPage),
+                        layout: layout,
+                        options: options,
+                        context: context
+                    )
+                    if !isAvailable, !unavailableNames.contains(item.fileName) {
+                        unavailableNames.append(item.fileName)
+                    }
+                }
+            } else {
+                drawEmptyState(in: context, rect: layout.contentRect)
+            }
+
+            drawFooter(
+                pageIndex: pageIndex,
+                pageCount: layout.pageCount,
+                margin: options.margin,
+                in: context,
+                pageSize: layout.pageSize
+            )
+            context.endPDFPage()
+        }
+        context.closePDF()
+
+        return ContactSheetPDFExport(
+            data: mutableData as Data,
+            layout: layout,
+            unavailableImageNames: unavailableNames
+        )
+    }
+
+    static func suggestedFilename(for title: String) -> String {
+        let disallowed = CharacterSet.alphanumerics
+            .union(.whitespaces)
+            .union(CharacterSet(charactersIn: "-_"))
+            .inverted
+        let components = title
+            .components(separatedBy: disallowed)
+            .joined(separator: "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let collapsed = components
+            .split(whereSeparator: { $0.isWhitespace })
+            .joined(separator: "-")
+        let base = collapsed.isEmpty ? "Contact-Sheet" : collapsed
+        return "\(base).pdf"
+    }
+
+    private static func drawPageBackground(in context: CGContext, pageSize: CGSize) {
+        context.saveGState()
+        context.setFillColor(NSColor.white.cgColor)
+        context.fill(CGRect(origin: .zero, size: pageSize))
+        context.restoreGState()
+    }
+
+    private static func drawHeader(
+        title: String,
+        itemCount: Int,
+        pageIndex: Int,
+        pageCount: Int,
+        options: ContactSheetExportOptions,
+        in context: CGContext,
+        pageSize: CGSize
+    ) {
+        let titleRect = CGRect(
+            x: options.margin,
+            y: pageSize.height - options.margin - 21,
+            width: pageSize.width - options.margin * 2,
+            height: 21
+        )
+        drawText(
+            title,
+            in: titleRect,
+            font: .systemFont(ofSize: 15, weight: .semibold),
+            color: darkText,
+            context: context
+        )
+
+        let noun = itemCount == 1 ? "image" : "images"
+        let subtitle = "\(itemCount) \(noun)  •  Page \(pageIndex + 1) of \(pageCount)"
+        let subtitleRect = CGRect(
+            x: options.margin,
+            y: titleRect.minY - 15,
+            width: titleRect.width,
+            height: 14
+        )
+        drawText(
+            subtitle,
+            in: subtitleRect,
+            font: .systemFont(ofSize: 9),
+            color: secondaryText,
+            context: context
+        )
+    }
+
+    private static func drawFooter(
+        pageIndex: Int,
+        pageCount: Int,
+        margin: CGFloat,
+        in context: CGContext,
+        pageSize: CGSize
+    ) {
+        let footerRect = CGRect(
+            x: margin,
+            y: max(4, margin - 14),
+            width: pageSize.width - margin * 2,
+            height: 12
+        )
+        drawText(
+            "Microfiche  •  \(pageIndex + 1) / \(pageCount)",
+            in: footerRect,
+            font: .systemFont(ofSize: 8),
+            color: secondaryText,
+            alignment: .right,
+            context: context
+        )
+    }
+
+    private static func draw(
+        item: ContactSheetExportItem,
+        in cellRect: CGRect,
+        layout: ContactSheetPDFLayout,
+        options: ContactSheetExportOptions,
+        context: CGContext
+    ) -> Bool {
+        let imageRect = CGRect(
+            x: cellRect.minX,
+            y: cellRect.maxY - layout.imageHeight,
+            width: cellRect.width,
+            height: layout.imageHeight
+        )
+        drawTile(in: context, rect: imageRect)
+
+        let image = loadPreviewImage(from: item.imageURL, maxPixelSize: max(imageRect.width, imageRect.height) * 2)
+        let isAvailable: Bool
+        if let image,
+           let cgImage = image.cgImage(forProposedRect: nil, context: nil, hints: nil) {
+            let destination = aspectFit(
+                sourceSize: CGSize(width: cgImage.width, height: cgImage.height),
+                in: imageRect.insetBy(dx: 3, dy: 3)
+            )
+            context.saveGState()
+            context.interpolationQuality = .high
+            context.draw(cgImage, in: destination)
+            context.restoreGState()
+            isAvailable = true
+        } else {
+            drawUnavailableImage(fileName: item.fileName, in: imageRect, context: context)
+            isAvailable = false
+        }
+
+        if layout.captionHeight > 0 {
+            let captionRect = CGRect(
+                x: cellRect.minX,
+                y: cellRect.minY,
+                width: cellRect.width,
+                height: max(0, layout.captionHeight - 4)
+            )
+            drawCaption(
+                item.captionLines(using: options.captions),
+                in: captionRect,
+                context: context
+            )
+        }
+        return isAvailable
+    }
+
+    private static func drawTile(in context: CGContext, rect: CGRect) {
+        let path = CGPath(
+            roundedRect: rect,
+            cornerWidth: 5,
+            cornerHeight: 5,
+            transform: nil
+        )
+        context.saveGState()
+        context.addPath(path)
+        context.setFillColor(tileBackground.cgColor)
+        context.fillPath()
+        context.addPath(path)
+        context.setStrokeColor(tileBorder.cgColor)
+        context.setLineWidth(0.5)
+        context.strokePath()
+        context.restoreGState()
+    }
+
+    private static func drawCaption(
+        _ lines: [String],
+        in rect: CGRect,
+        context: CGContext
+    ) {
+        guard !lines.isEmpty else { return }
+        var currentY = rect.maxY - ContactSheetPDFLayout.captionLineHeight
+        for (index, line) in lines.enumerated() where currentY >= rect.minY {
+            drawText(
+                line,
+                in: CGRect(
+                    x: rect.minX,
+                    y: currentY,
+                    width: rect.width,
+                    height: ContactSheetPDFLayout.captionLineHeight
+                ),
+                font: .systemFont(ofSize: index == 0 ? 8.5 : 7.5, weight: index == 0 ? .medium : .regular),
+                color: index == 0 ? darkText : secondaryText,
+                context: context
+            )
+            currentY -= ContactSheetPDFLayout.captionLineHeight
+        }
+    }
+
+    private static func drawUnavailableImage(
+        fileName: String,
+        in rect: CGRect,
+        context: CGContext
+    ) {
+        let messageRect = rect.insetBy(dx: 8, dy: 8)
+        drawText(
+            "Image unavailable\n\(fileName)",
+            in: messageRect,
+            font: .systemFont(ofSize: 8, weight: .medium),
+            color: secondaryText,
+            alignment: .center,
+            lineBreakMode: .byWordWrapping,
+            context: context
+        )
+    }
+
+    private static func drawEmptyState(in context: CGContext, rect: CGRect) {
+        drawText(
+            "No images in this contact sheet",
+            in: rect.insetBy(dx: 20, dy: 20),
+            font: .systemFont(ofSize: 13, weight: .medium),
+            color: secondaryText,
+            alignment: .center,
+            context: context
+        )
+    }
+
+    private static func drawText(
+        _ text: String,
+        in rect: CGRect,
+        font: NSFont,
+        color: NSColor,
+        alignment: NSTextAlignment = .left,
+        lineBreakMode: NSLineBreakMode = .byTruncatingTail,
+        context: CGContext
+    ) {
+        let paragraph = NSMutableParagraphStyle()
+        paragraph.alignment = alignment
+        paragraph.lineBreakMode = lineBreakMode
+        let attributed = NSAttributedString(
+            string: text,
+            attributes: [
+                .font: font,
+                .foregroundColor: color,
+                .paragraphStyle: paragraph
+            ]
+        )
+
+        NSGraphicsContext.saveGraphicsState()
+        NSGraphicsContext.current = NSGraphicsContext(cgContext: context, flipped: false)
+        attributed.draw(
+            with: rect,
+            options: [.usesLineFragmentOrigin, .usesFontLeading, .truncatesLastVisibleLine]
+        )
+        NSGraphicsContext.restoreGraphicsState()
+    }
+
+    private static func loadPreviewImage(from url: URL, maxPixelSize: CGFloat) -> NSImage? {
+        guard FileManager.default.fileExists(atPath: url.path) else { return nil }
+        if url.pathExtension.lowercased() == "pdf",
+           let document = PDFDocument(url: url),
+           let page = document.page(at: 0) {
+            return page.thumbnail(
+                of: CGSize(width: maxPixelSize, height: maxPixelSize),
+                for: .cropBox
+            )
+        }
+        return ImageThumbnailGenerator.thumbnail(from: url, maxPixelSize: maxPixelSize)
+            ?? NSImage(contentsOf: url)
+    }
+
+    private static func aspectFit(sourceSize: CGSize, in destination: CGRect) -> CGRect {
+        guard sourceSize.width > 0, sourceSize.height > 0 else { return destination }
+        let scale = min(
+            destination.width / sourceSize.width,
+            destination.height / sourceSize.height
+        )
+        let size = CGSize(width: sourceSize.width * scale, height: sourceSize.height * scale)
+        return CGRect(
+            x: destination.midX - size.width / 2,
+            y: destination.midY - size.height / 2,
+            width: size.width,
+            height: size.height
+        )
+    }
+}

--- a/Microfiche/Services/ContactSheetStorage.swift
+++ b/Microfiche/Services/ContactSheetStorage.swift
@@ -142,6 +142,17 @@ class ContactSheetStorage: ObservableObject {
         }
     }
 
+    /// Preserves contact-sheet order and original filenames for portable exports.
+    /// Records remain present when a stored file is missing so the exporter can
+    /// draw a placeholder and report the unavailable image.
+    func getImageRecords(for contactSheetID: UUID) -> [ContactSheetImage] {
+        guard let contactSheet = contactSheets.first(where: { $0.id == contactSheetID }) else {
+            return []
+        }
+
+        return contactSheet.imageIDs.compactMap { imageMap[$0] }
+    }
+
     // MARK: - Private Helpers
 
     private func existingImageID(for sourceURL: URL) -> UUID? {

--- a/Microfiche/Views/ContactSheetExportView.swift
+++ b/Microfiche/Views/ContactSheetExportView.swift
@@ -1,0 +1,337 @@
+//
+//  ContactSheetExportView.swift
+//  Microfiche
+//
+
+import AppKit
+import PDFKit
+import SwiftUI
+import UniformTypeIdentifiers
+
+struct ContactSheetExportView: View {
+    let contactSheet: ContactSheet
+    let items: [ContactSheetExportItem]
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var options = ContactSheetExportOptions()
+    @State private var previewState = ContactSheetExportPreviewState()
+    @State private var temporaryShareURL: URL?
+    @State private var lastSavedURL: URL?
+    @State private var exportError: String?
+
+    var body: some View {
+        NavigationStack {
+            HStack(spacing: 0) {
+                settingsPanel
+                    .frame(width: 270)
+
+                Divider()
+
+                previewPanel
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
+            .navigationTitle("Export \(contactSheet.name)")
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+
+                ToolbarItemGroup {
+                    if let shareURL = lastSavedURL ?? temporaryShareURL {
+                        ShareLink(item: shareURL) {
+                            Label("Share", systemImage: "square.and.arrow.up")
+                        }
+                        .help("Share PDF")
+                        .accessibilityIdentifier("share-contact-sheet-pdf")
+                    }
+
+                    Button {
+                        revealLastExport()
+                    } label: {
+                        Label("Reveal", systemImage: "folder")
+                    }
+                    .disabled(lastSavedURL == nil)
+                    .help("Reveal Last Export in Finder")
+                    .accessibilityIdentifier("reveal-contact-sheet-pdf")
+
+                    Button("Save PDF…") {
+                        savePDF()
+                    }
+                    .disabled(currentExport == nil)
+                    .keyboardShortcut(.defaultAction)
+                    .accessibilityIdentifier("save-contact-sheet-pdf")
+                }
+            }
+        }
+        .frame(minWidth: 860, idealWidth: 980, minHeight: 620, idealHeight: 720)
+        .accessibilityIdentifier("contact-sheet-export-view")
+        .task(id: options) {
+            await renderPreview()
+        }
+        .alert(
+            "Couldn’t Export Contact Sheet",
+            isPresented: Binding(
+                get: { exportError != nil },
+                set: { if !$0 { exportError = nil } }
+            )
+        ) {
+            Button("OK") { exportError = nil }
+        } message: {
+            Text(exportError ?? "")
+        }
+    }
+
+    private var settingsPanel: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 22) {
+                pageSettings
+                captionSettings
+                exportSummary
+            }
+            .padding(20)
+        }
+        .background(Color(NSColor.controlBackgroundColor).opacity(0.45))
+    }
+
+    private var pageSettings: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Page")
+                .font(.headline)
+
+            Picker("Paper", selection: $options.paperSize) {
+                ForEach(ContactSheetPaperSize.allCases) { paperSize in
+                    Text(paperSize.rawValue).tag(paperSize)
+                }
+            }
+
+            Picker("Orientation", selection: $options.orientation) {
+                ForEach(ContactSheetPageOrientation.allCases) { orientation in
+                    Text(orientation.rawValue).tag(orientation)
+                }
+            }
+            .pickerStyle(.segmented)
+
+            Stepper("Columns: \(options.columns)", value: $options.columns, in: 2...6)
+
+            VStack(alignment: .leading, spacing: 6) {
+                HStack {
+                    Text("Margins")
+                    Spacer()
+                    Text("\(Int(options.margin)) pt")
+                        .foregroundStyle(.secondary)
+                        .monospacedDigit()
+                }
+                Slider(value: $options.margin, in: 24...72, step: 6)
+                    .accessibilityLabel("Page margins")
+                    .accessibilityValue("\(Int(options.margin)) points")
+            }
+        }
+    }
+
+    private var captionSettings: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("Captions")
+                .font(.headline)
+
+            Toggle("Filename", isOn: $options.captions.includesFilename)
+            Toggle("Finder label", isOn: $options.captions.includesFinderLabel)
+            Toggle("Tags", isOn: $options.captions.includesTags)
+            Toggle("Comments", isOn: $options.captions.includesComments)
+            Toggle("Source", isOn: $options.captions.includesSource)
+        }
+    }
+
+    @ViewBuilder
+    private var exportSummary: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Preview")
+                .font(.headline)
+
+            switch previewState.phase {
+            case .idle, .loading:
+                HStack(spacing: 8) {
+                    ProgressView()
+                        .controlSize(.small)
+                    Text("Building PDF…")
+                }
+                .foregroundStyle(.secondary)
+
+            case .ready(let export):
+                let count = export.layout.pageCount
+                Label(
+                    "\(count) \(count == 1 ? "page" : "pages")",
+                    systemImage: "doc"
+                )
+                .foregroundStyle(.secondary)
+
+                if items.isEmpty {
+                    Label("Contact sheet is empty", systemImage: "photo.on.rectangle.angled")
+                        .foregroundStyle(.secondary)
+                }
+
+                if !export.unavailableImageNames.isEmpty {
+                    Label(
+                        "\(export.unavailableImageNames.count) unavailable",
+                        systemImage: "exclamationmark.triangle"
+                    )
+                    .foregroundStyle(.orange)
+
+                    Text(export.unavailableImageNames.joined(separator: ", "))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(4)
+                        .textSelection(.enabled)
+                }
+
+            case .failed(let message):
+                Label(message, systemImage: "exclamationmark.triangle")
+                    .font(.caption)
+                    .foregroundStyle(.red)
+
+                Button("Try Again") {
+                    Task { await renderPreview() }
+                }
+                .controlSize(.small)
+            }
+        }
+    }
+
+    private var previewPanel: some View {
+        ZStack {
+            Color(NSColor.windowBackgroundColor)
+
+            switch previewState.phase {
+            case .ready(let export):
+                ContactSheetPDFDataView(data: export.data)
+                    .padding(18)
+
+            case .failed:
+                ContentUnavailableView(
+                    "Preview Unavailable",
+                    systemImage: "doc.badge.ellipsis",
+                    description: Text("Adjust an option or try again.")
+                )
+
+            case .idle, .loading:
+                ProgressView("Building preview…")
+                    .controlSize(.large)
+            }
+        }
+    }
+
+    private var currentExport: ContactSheetPDFExport? {
+        guard case .ready(let export) = previewState.phase else { return nil }
+        return export
+    }
+
+    private func renderPreview() async {
+        let requestID = previewState.beginLoading()
+        lastSavedURL = nil
+        temporaryShareURL = nil
+        let requestedOptions = options
+        let requestedItems = items
+        let title = contactSheet.name
+
+        let result = await Task.detached(priority: .userInitiated) {
+            do {
+                return Result<ContactSheetPDFExport, ContactSheetPDFExportError>.success(
+                    try ContactSheetPDFExporter.render(
+                        title: title,
+                        items: requestedItems,
+                        options: requestedOptions
+                    )
+                )
+            } catch let error as ContactSheetPDFExportError {
+                return .failure(error)
+            } catch {
+                return .failure(.unableToCreateContext)
+            }
+        }.value
+
+        if Task.isCancelled {
+            previewState.cancel(requestID: requestID)
+            return
+        }
+
+        guard previewState.finish(result, requestID: requestID) else { return }
+        if case .success(let export) = result {
+            prepareTemporaryShareFile(using: export.data)
+        }
+    }
+
+    private func prepareTemporaryShareFile(using data: Data) {
+        let fileManager = FileManager.default
+        let directory = fileManager.temporaryDirectory
+            .appendingPathComponent("Microfiche", isDirectory: true)
+            .appendingPathComponent("ContactSheetExports", isDirectory: true)
+        do {
+            try fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+            let url = directory.appendingPathComponent(
+                ContactSheetPDFExporter.suggestedFilename(for: contactSheet.name)
+            )
+            try data.write(to: url, options: .atomic)
+            temporaryShareURL = url
+        } catch {
+            temporaryShareURL = nil
+        }
+    }
+
+    private func savePDF() {
+        guard let export = currentExport else { return }
+
+        let panel = NSSavePanel()
+        panel.allowedContentTypes = [.pdf]
+        panel.canCreateDirectories = true
+        panel.isExtensionHidden = false
+        panel.nameFieldStringValue = ContactSheetPDFExporter.suggestedFilename(
+            for: contactSheet.name
+        )
+
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+        do {
+            try export.data.write(to: url, options: .atomic)
+            lastSavedURL = url
+            exportError = nil
+        } catch {
+            exportError = error.localizedDescription
+        }
+    }
+
+    private func revealLastExport() {
+        guard let lastSavedURL else { return }
+        NSWorkspace.shared.activateFileViewerSelecting([lastSavedURL])
+    }
+}
+
+private struct ContactSheetPDFDataView: NSViewRepresentable {
+    let data: Data
+
+    final class Coordinator {
+        var data: Data?
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator()
+    }
+
+    func makeNSView(context: Context) -> PDFView {
+        let view = PDFView()
+        view.autoScales = true
+        view.displayMode = .singlePageContinuous
+        view.displayDirection = .vertical
+        view.displaysPageBreaks = true
+        view.backgroundColor = .windowBackgroundColor
+        updateDocument(in: view, coordinator: context.coordinator)
+        return view
+    }
+
+    func updateNSView(_ nsView: PDFView, context: Context) {
+        updateDocument(in: nsView, coordinator: context.coordinator)
+    }
+
+    private func updateDocument(in view: PDFView, coordinator: Coordinator) {
+        guard coordinator.data != data else { return }
+        view.document = PDFDocument(data: data)
+        coordinator.data = data
+    }
+}

--- a/Microfiche/Views/SidebarView.swift
+++ b/Microfiche/Views/SidebarView.swift
@@ -22,6 +22,7 @@ struct SidebarView: View {
     let onCreateContactSheet: () -> Void
     let onRenameContactSheet: (UUID, String) -> Void
     let onDeleteContactSheet: (UUID) -> Void
+    let onExportContactSheet: (UUID) -> Void
     let onDropToContactSheet: (UUID, [URL]) -> Void
 
     var body: some View {
@@ -100,6 +101,9 @@ struct SidebarView: View {
                                 },
                                 onDelete: {
                                     onDeleteContactSheet(sheet.id)
+                                },
+                                onExport: {
+                                    onExportContactSheet(sheet.id)
                                 },
                                 onDrop: { urls in
                                     onDropToContactSheet(sheet.id, urls)
@@ -405,14 +409,16 @@ struct ContactSheetSidebarItem: View {
     let onSelect: () -> Void
     let onRename: (String) -> Void
     let onDelete: () -> Void
+    let onExport: () -> Void
     let onDrop: ([URL]) -> Void
 
-    init(contactSheet: ContactSheet, isSelected: Bool, onSelect: @escaping () -> Void, onRename: @escaping (String) -> Void, onDelete: @escaping () -> Void, onDrop: @escaping ([URL]) -> Void) {
+    init(contactSheet: ContactSheet, isSelected: Bool, onSelect: @escaping () -> Void, onRename: @escaping (String) -> Void, onDelete: @escaping () -> Void, onExport: @escaping () -> Void, onDrop: @escaping ([URL]) -> Void) {
         self.contactSheet = contactSheet
         self.isSelected = isSelected
         self.onSelect = onSelect
         self.onRename = onRename
         self.onDelete = onDelete
+        self.onExport = onExport
         self.onDrop = onDrop
         _editedName = State(initialValue: contactSheet.name)
     }
@@ -481,6 +487,10 @@ struct ContactSheetSidebarItem: View {
         )
         .accessibilityIdentifier("contact-sheet-\(contactSheet.id.uuidString)-drop-target")
         .contextMenu {
+            Button("Export PDF…") {
+                onExport()
+            }
+            Divider()
             Button("Rename") {
                 beginRenaming()
             }

--- a/MicroficheTests/MicroficheTests.swift
+++ b/MicroficheTests/MicroficheTests.swift
@@ -5,6 +5,7 @@
 //  Created by David Hoang on 6/8/25.
 //
 
+import PDFKit
 import XCTest
 @testable import Microfiche
 
@@ -407,6 +408,248 @@ final class MicroficheTests: XCTestCase {
         XCTAssertEqual(secondID, firstID)
         XCTAssertEqual(storage.getImages(for: firstSheet.id).count, 1)
         XCTAssertEqual(storage.getImages(for: secondSheet.id).count, 1)
+    }
+
+    func testContactSheetExportRecordsPreserveOrderWhenStoredImageIsMissing() throws {
+        let fileManager = FileManager.default
+        let testDirectory = fileManager.temporaryDirectory
+            .appendingPathComponent("microfiche-contact-sheet-export-records-\(UUID().uuidString)")
+        let firstURL = testDirectory.appendingPathComponent("first.png")
+        let secondURL = testDirectory.appendingPathComponent("second.png")
+        let pngData = Data(base64Encoded:
+            "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="
+        )!
+
+        try fileManager.createDirectory(at: testDirectory, withIntermediateDirectories: true)
+        try pngData.write(to: firstURL)
+        try pngData.write(to: secondURL)
+        defer { try? fileManager.removeItem(at: testDirectory) }
+
+        let storage = ContactSheetStorage(baseDirectory: testDirectory, fileManager: fileManager)
+        let sheet = storage.createContactSheet(name: "Export Order")
+        XCTAssertEqual(storage.addImages(from: [firstURL, secondURL], to: sheet.id).count, 2)
+
+        let records = storage.getImageRecords(for: sheet.id)
+        XCTAssertEqual(records.map(\.fileName), ["first.png", "second.png"])
+        try fileManager.removeItem(at: records[0].storedURL)
+
+        let recordsAfterRemoval = storage.getImageRecords(for: sheet.id)
+        XCTAssertEqual(recordsAfterRemoval.map(\.fileName), ["first.png", "second.png"])
+        XCTAssertFalse(fileManager.fileExists(atPath: recordsAfterRemoval[0].storedURL.path))
+    }
+
+    func testContactSheetPDFLayoutSupportsPaperOrientationMarginsAndPagination() {
+        var portraitOptions = ContactSheetExportOptions()
+        portraitOptions.paperSize = .letter
+        portraitOptions.orientation = .portrait
+        portraitOptions.columns = 4
+        portraitOptions.margin = 36
+        let portrait = ContactSheetPDFLayout(itemCount: 1, options: portraitOptions)
+
+        XCTAssertEqual(portrait.pageSize.width, 612, accuracy: 0.01)
+        XCTAssertEqual(portrait.pageSize.height, 792, accuracy: 0.01)
+        XCTAssertEqual(portrait.columns, 4)
+        XCTAssertGreaterThanOrEqual(portrait.rowsPerPage, 1)
+
+        let multiPage = ContactSheetPDFLayout(
+            itemCount: portrait.itemsPerPage + 1,
+            options: portraitOptions
+        )
+        XCTAssertEqual(multiPage.pageCount, 2)
+
+        var landscapeOptions = portraitOptions
+        landscapeOptions.paperSize = .a4
+        landscapeOptions.orientation = .landscape
+        landscapeOptions.columns = 6
+        landscapeOptions.margin = 72
+        let landscape = ContactSheetPDFLayout(itemCount: 1, options: landscapeOptions)
+
+        XCTAssertEqual(landscape.pageSize.width, 841.89, accuracy: 0.01)
+        XCTAssertEqual(landscape.pageSize.height, 595.28, accuracy: 0.01)
+        XCTAssertEqual(landscape.columns, 6)
+        XCTAssertEqual(landscape.contentRect.minX, 72, accuracy: 0.01)
+        let firstItemRect = landscape.itemRect(at: 0)
+        XCTAssertGreaterThanOrEqual(firstItemRect.minX, landscape.contentRect.minX - 0.01)
+        XCTAssertLessThanOrEqual(firstItemRect.maxX, landscape.contentRect.maxX + 0.01)
+        XCTAssertGreaterThanOrEqual(firstItemRect.minY, landscape.contentRect.minY - 0.01)
+        XCTAssertLessThanOrEqual(firstItemRect.maxY, landscape.contentRect.maxY + 0.01)
+
+        var normalizedOptions = portraitOptions
+        normalizedOptions.margin = 500
+        normalizedOptions.columns = 99
+        XCTAssertEqual(normalizedOptions.normalized.margin, 72)
+        XCTAssertEqual(normalizedOptions.normalized.columns, 6)
+    }
+
+    func testContactSheetPDFExporterRendersEmptyAndMissingImageStates() throws {
+        let emptyExport = try ContactSheetPDFExporter.render(
+            title: "Empty Sheet",
+            items: [],
+            options: ContactSheetExportOptions()
+        )
+        let emptyDocument = try XCTUnwrap(PDFDocument(data: emptyExport.data))
+
+        XCTAssertEqual(emptyDocument.pageCount, 1)
+        XCTAssertTrue(emptyDocument.string?.contains("No images in this contact sheet") == true)
+        XCTAssertTrue(emptyExport.unavailableImageNames.isEmpty)
+
+        let missingURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("missing-\(UUID().uuidString).jpg")
+        let missingItem = ContactSheetExportItem(
+            id: UUID(),
+            fileName: "offline-photo.jpg",
+            imageURL: missingURL,
+            finderLabel: nil,
+            tags: [],
+            comments: "",
+            source: ""
+        )
+        let missingExport = try ContactSheetPDFExporter.render(
+            title: "Offline Sheet",
+            items: [missingItem],
+            options: ContactSheetExportOptions()
+        )
+        let missingDocument = try XCTUnwrap(PDFDocument(data: missingExport.data))
+
+        XCTAssertEqual(missingDocument.pageCount, 1)
+        XCTAssertEqual(missingExport.unavailableImageNames, ["offline-photo.jpg"])
+        XCTAssertTrue(missingDocument.string?.contains("Image unavailable") == true)
+        XCTAssertTrue(missingDocument.string?.contains("offline-photo.jpg") == true)
+    }
+
+    func testContactSheetPDFExporterIncludesMetadataAcrossRepeatedMultiPageExports() throws {
+        let fileManager = FileManager.default
+        let imageURL = fileManager.temporaryDirectory
+            .appendingPathComponent("microfiche-pdf-export-\(UUID().uuidString).png")
+        let pngData = Data(base64Encoded:
+            "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="
+        )!
+        try pngData.write(to: imageURL)
+        defer { try? fileManager.removeItem(at: imageURL) }
+
+        var options = ContactSheetExportOptions()
+        options.columns = 2
+        options.captions = ContactSheetCaptionOptions(
+            includesFilename: true,
+            includesFinderLabel: true,
+            includesTags: true,
+            includesComments: true,
+            includesSource: true
+        )
+        let layout = ContactSheetPDFLayout(itemCount: 1, options: options)
+        let itemCount = layout.itemsPerPage + 1
+        let items = (0..<itemCount).map { index in
+            ContactSheetExportItem(
+                id: UUID(),
+                fileName: "photo-\(index).png",
+                imageURL: imageURL,
+                finderLabel: "Orange",
+                tags: ["keeper", "portrait"],
+                comments: "Looks\n good",
+                source: "Camera roll"
+            )
+        }
+
+        for _ in 0..<2 {
+            let export = try ContactSheetPDFExporter.render(
+                title: "Repeated Export",
+                items: items,
+                options: options
+            )
+            let document = try XCTUnwrap(PDFDocument(data: export.data))
+            let extractedText = document.string ?? ""
+
+            XCTAssertEqual(document.pageCount, 2)
+            XCTAssertTrue(export.unavailableImageNames.isEmpty)
+            XCTAssertTrue(extractedText.contains("photo-0.png"))
+            XCTAssertTrue(extractedText.contains("Label: Orange"))
+            XCTAssertTrue(extractedText.contains("Tags: keeper, portrait"))
+            XCTAssertTrue(extractedText.contains("Comments: Looks good"))
+            XCTAssertTrue(extractedText.contains("Source: Camera roll"))
+        }
+    }
+
+    func testContactSheetExportPreviewStateRejectsStaleResultsAndSupportsRetryAndCancellation() {
+        var state = ContactSheetExportPreviewState()
+        let options = ContactSheetExportOptions()
+        let export = ContactSheetPDFExport(
+            data: Data([0x25, 0x50, 0x44, 0x46]),
+            layout: ContactSheetPDFLayout(itemCount: 0, options: options),
+            unavailableImageNames: []
+        )
+
+        let firstRequest = state.beginLoading()
+        let secondRequest = state.beginLoading()
+        XCTAssertFalse(state.finish(.success(export), requestID: firstRequest))
+        XCTAssertEqual(state.phase, .loading)
+        XCTAssertTrue(state.finish(.success(export), requestID: secondRequest))
+        XCTAssertEqual(state.phase, .ready(export))
+
+        let failedRequest = state.beginLoading()
+        XCTAssertTrue(state.finish(.failure(.unableToCreateContext), requestID: failedRequest))
+        guard case .failed(let message) = state.phase else {
+            return XCTFail("Expected failed preview state")
+        }
+        XCTAssertFalse(message.isEmpty)
+
+        let retryRequest = state.beginLoading()
+        XCTAssertEqual(state.phase, .loading)
+        XCTAssertTrue(state.cancel(requestID: retryRequest))
+        XCTAssertEqual(state.phase, .idle)
+        XCTAssertFalse(state.cancel(requestID: retryRequest))
+    }
+
+    func testContactSheetExportSuggestedFilenameIsPortable() {
+        XCTAssertEqual(
+            ContactSheetPDFExporter.suggestedFilename(for: "Client Review / Finals"),
+            "Client-Review-Finals.pdf"
+        )
+        XCTAssertEqual(ContactSheetPDFExporter.suggestedFilename(for: "///"), "Contact-Sheet.pdf")
+    }
+
+    func testContactSheetCaptionOptionsCanHideOrShowEveryMetadataField() {
+        let item = ContactSheetExportItem(
+            id: UUID(),
+            fileName: "selected.jpg",
+            imageURL: URL(fileURLWithPath: "/tmp/selected.jpg"),
+            finderLabel: "Purple",
+            tags: ["hero", "approved"],
+            comments: "Line one\nline two",
+            source: "Campaign library"
+        )
+        let hidden = ContactSheetCaptionOptions(
+            includesFilename: false,
+            includesFinderLabel: false,
+            includesTags: false,
+            includesComments: false,
+            includesSource: false
+        )
+        let shown = ContactSheetCaptionOptions(
+            includesFilename: true,
+            includesFinderLabel: true,
+            includesTags: true,
+            includesComments: true,
+            includesSource: true
+        )
+
+        XCTAssertTrue(item.captionLines(using: hidden).isEmpty)
+        XCTAssertEqual(
+            item.captionLines(using: shown),
+            [
+                "selected.jpg",
+                "Label: Purple",
+                "Tags: hero, approved",
+                "Comments: Line one line two",
+                "Source: Campaign library"
+            ]
+        )
+
+        var hiddenOptions = ContactSheetExportOptions()
+        hiddenOptions.captions = hidden
+        XCTAssertEqual(
+            ContactSheetPDFLayout(itemCount: 1, options: hiddenOptions).captionHeight,
+            0
+        )
     }
 
     func testImageDropPayloadLoadsMultipleFileURLsOnceInProviderOrder() throws {


### PR DESCRIPTION
## Summary

- add native paginated PDF export for saved contact sheets
- support Letter/A4, portrait/landscape, configurable margins and columns
- add optional filename, Finder label, tags, comments, and source captions
- preview page count and layout before saving
- report missing images with PDF placeholders instead of aborting
- add Save, Share, and Reveal in Finder actions
- expose export from the contact-sheet toolbar and context menu

## Verification

- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild -project Microfiche.xcodeproj -scheme Microfiche -configuration Debug -destination platform=macOS test` — passed, 48 executions and 0 failures
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild -project Microfiche.xcodeproj -scheme Microfiche -configuration Debug -destination generic/platform=macOS CODE_SIGNING_ALLOWED=NO build` — succeeded
- rendered and visually inspected portrait and landscape two-page PDFs, including metadata captions and an unavailable-image placeholder
- repeated export, stale preview, cancellation, retry, empty sheet, missing image, metadata toggles, paper sizes, orientations, margins, columns, and storage ordering are covered

## Manual verification remaining

- system save-panel cancellation/write-failure paths
- completion of the system share sheet

[Jira: PCD-30](https://dh-studios.atlassian.net/browse/PCD-30)