### PR TITLE
Polish welcome onboarding copy

### DIFF
--- a/Microfiche/Views/OnboardingView.swift
+++ b/Microfiche/Views/OnboardingView.swift
@@ -36,7 +36,7 @@ struct OnboardingView: View {
                         }
                         .buttonStyle(.plain)
                         .foregroundStyle(.secondary)
-                        .help("Skip welcome onboarding")
+                        .help("Skip Welcome Onboarding")
                     }
                     .padding(.horizontal, 28)
                     .padding(.top, 20)
@@ -86,7 +86,7 @@ struct OnboardingView: View {
                                 .buttonStyle(.borderedProminent)
                                 .keyboardShortcut(.defaultAction)
 
-                                Button("Start Browsing") {
+                                Button("Browse Library") {
                                     finish()
                                 }
                                 .buttonStyle(.bordered)
@@ -130,25 +130,25 @@ struct OnboardingStep: Identifiable, Equatable {
             id: "welcome",
             symbolName: "photo.on.rectangle.angled",
             title: "Your library, left in place",
-            message: "Microfiche browses photos where they already live. No import, no copies — just a durable view of your folders and drives."
+            message: "Microfiche browses photos where they already live. No import, no copies — just a fast view of your folders and drives."
         ),
         OnboardingStep(
             id: "folders",
             symbolName: "folder.badge.plus",
             title: "Link folders and drives",
-            message: "Add folders from your Mac or external volumes. Microfiche remembers them and reconnects when a drive comes back online."
+            message: "Add folders from your Mac, iCloud Drive, or external volumes. Microfiche remembers them and reconnects when a drive comes back online."
         ),
         OnboardingStep(
             id: "contact-sheets",
             symbolName: "rectangle.stack",
-            title: "Curate with Contact Sheets",
-            message: "Gather selects into Contact Sheets that stay available even if the original drive is offline."
+            title: "Keep selects on Contact Sheets",
+            message: "Gather images into Contact Sheets from any linked folder. Sheets stay in your library even when a drive is offline."
         ),
         OnboardingStep(
             id: "metadata",
             symbolName: "tag",
-            title: "Labels, tags, and notes that stick",
-            message: "Edit Finder labels, tags, and comments right from the inspector — written where Finder and other apps can see them."
+            title: "Labels, tags, and comments",
+            message: "Edit Finder labels, tags, and comments in the inspector. Changes write to the file so Finder and other apps can see them."
         )
     ]
 }

--- a/MicroficheTests/MicroficheTests.swift
+++ b/MicroficheTests/MicroficheTests.swift
@@ -1052,6 +1052,16 @@ final class MicroficheTests: XCTestCase {
         let steps = OnboardingStep.all
         XCTAssertEqual(steps.count, 4)
         XCTAssertEqual(steps.map(\.id), ["welcome", "folders", "contact-sheets", "metadata"])
+        XCTAssertEqual(steps.map(\.title), [
+            "Your library, left in place",
+            "Link folders and drives",
+            "Keep selects on Contact Sheets",
+            "Labels, tags, and comments"
+        ])
+        XCTAssertTrue(steps[0].message.contains("No import, no copies"))
+        XCTAssertTrue(steps[1].message.contains("iCloud Drive"))
+        XCTAssertTrue(steps[2].message.contains("offline"))
+        XCTAssertTrue(steps[3].message.contains("Finder"))
         XCTAssertTrue(steps.allSatisfy { !$0.title.isEmpty && !$0.message.isEmpty && !$0.symbolName.isEmpty })
     }
 

--- a/design.md
+++ b/design.md
@@ -175,6 +175,7 @@ Disable animations while the grid size slider is dragging. Prefer `MicroficheMot
 2. **Name the target** — “Remove Folder”, “Forget Drive”, “Move to Trash” — not vague “Delete” when the object matters.
 3. **Short toolbar help** — Verb phrases: “Thumbnail Size”, “Back to Library”, “Show Info”.
 4. **Status is factual** — “Offline”, “Connected”, “3 linked folders • 1 offline”.
+5. **Onboarding stays concrete** — One benefit per step; say what the user does and what they get. Prefer product terms already in the UI (Contact Sheets, Finder labels/tags/comments, Link a Folder) over marketing verbs.
 
 ---
 
@@ -215,6 +216,7 @@ Disable animations while the grid size slider is dragging. Prefer `MicroficheMot
 - Full-window dimmed overlay + `LiquidGlassPanel` (same modal pattern as quick preview).
 - Shows once until completed/skipped when **Settings → Onboarding → Show welcome onboarding** is on.
 - Testing: toggle the setting off to suppress; use **Replay Onboarding** or **Help → Replay Welcome Onboarding** to walk through again.
+- **Copy:** Four steps, one job each — in-place library, linked folders/drives, Contact Sheets, Finder metadata. Titles are short and direct; body copy is one instructional sentence plus the payoff. Final CTAs: **Link a Folder** / **Browse Library**.
 
 ### Archive folder
 - **Files:** `Services/ArchiveFolderStore.swift`, `Services/FileArchiver.swift`, `SettingsView.swift`


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Rewrites the four welcome onboarding steps to match Microfiche’s direct copy tone: one concrete benefit per step, product terms already used in the UI, and Finder-accurate metadata language.
- Renames the final dismiss CTA from **Start Browsing** to **Browse Library**.
- Locks step titles and key phrases in `testOnboardingSequenceCoversValueProposition`, and documents onboarding copy guidance in `design.md`.

### Copy
1. **Your library, left in place** — in-place browsing; no import/copies; fast folder/drive view
2. **Link folders and drives** — Mac, iCloud Drive, external volumes; reconnect when drives return
3. **Keep selects on Contact Sheets** — gather from linked folders; sheets survive offline drives
4. **Labels, tags, and comments** — edit in inspector; writes where Finder and other apps can see them

Final CTAs: **Link a Folder** / **Browse Library**

## How to test
1. **Help → Replay Welcome Onboarding** (or Settings → Onboarding → Replay).
2. Confirm each step’s title and body read clearly and fit the panel without clipping.
3. Walk Continue through all four steps twice; confirm Back returns to prior copy.
4. On the last step, confirm **Link a Folder** and **Browse Library** dismiss correctly.
5. Skip from an early step and confirm onboarding does not reappear until Replay.

## Verification notes
- This environment is Linux-only (no Xcode). Build and `xcodebuild test` were not run here; please verify on macOS with the commands in `TESTING.md`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fc821-52f7-791e-887d-4d4ffa086cb5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fc821-52f7-791e-887d-4d4ffa086cb5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

