### PR TITLE
PCD-25: Cover library index cancellation and unavailable storage

### DIFF
--- a/Microfiche/Services/LibraryIndexStore.swift
+++ b/Microfiche/Services/LibraryIndexStore.swift
@@ -149,6 +149,9 @@ final class LibraryIndexStore: ObservableObject {
     private var mutationVersions: [UUID: UInt64] = [:]
     private var fileSystemChangeTasks: [UUID: Task<Void, Never>] = [:]
     private var fileSystemChangeGenerations: [UUID: UUID] = [:]
+    #if DEBUG
+    var testWillScan: (() async -> Void)?
+    #endif
 
     init(
         persistenceURL customPersistenceURL: URL? = nil,
@@ -232,6 +235,12 @@ final class LibraryIndexStore: ObservableObject {
         let generation = UUID()
         let mutationVersion = mutationVersions[folderID, default: 0]
         reconcileGenerations[folderID] = generation
+
+        #if DEBUG
+        if let testWillScan {
+            await testWillScan()
+        }
+        #endif
 
         let entries = await Task.detached(priority: .userInitiated) {
             LibraryIndexScanner.scan(root: root)

--- a/MicroficheTests/MicroficheTests.swift
+++ b/MicroficheTests/MicroficheTests.swift
@@ -383,16 +383,153 @@ final class MicroficheTests: XCTestCase {
         XCTAssertEqual(restored.files(for: [folder.id]).map(\.url), [newURL])
     }
 
-    private func makeLinkedFolder(url: URL) -> LinkedLibraryFolder {
+    @MainActor
+    func testLibraryIndexRepeatedReconcileDoesNotReplaceUnchangedState() async throws {
+        let fileManager = FileManager.default
+        let root = fileManager.temporaryDirectory
+            .appendingPathComponent("microfiche-index-repeat-\(UUID().uuidString)")
+        let photos = root.appendingPathComponent("Photos", isDirectory: true)
+        let persistenceURL = root.appendingPathComponent("library-index.json")
+        let imageURL = photos.appendingPathComponent("keep.jpg")
+        try fileManager.createDirectory(at: photos, withIntermediateDirectories: true)
+        try Data("image".utf8).write(to: imageURL)
+        defer { try? fileManager.removeItem(at: root) }
+
+        let folder = makeLinkedFolder(url: photos)
+        let store = LibraryIndexStore(
+            persistenceURL: persistenceURL,
+            watchesFileSystem: false
+        )
+        store.configure(folders: [folder])
+        await store.reconcile(folderID: folder.id)
+        let revisionAfterFirst = store.revision
+
+        await store.reconcile(folderID: folder.id)
+        await store.reconcile(folderID: folder.id)
+
+        XCTAssertEqual(store.revision, revisionAfterFirst)
+        XCTAssertEqual(store.files(for: [folder.id]).map(\.url), [imageURL])
+    }
+
+    @MainActor
+    func testLibraryIndexCancelsStaleReconcileAfterLocalMutation() async throws {
+        let fileManager = FileManager.default
+        let root = fileManager.temporaryDirectory
+            .appendingPathComponent("microfiche-index-cancel-\(UUID().uuidString)")
+        let photos = root.appendingPathComponent("Photos", isDirectory: true)
+        let persistenceURL = root.appendingPathComponent("library-index.json")
+        let imageURL = photos.appendingPathComponent("stay.jpg")
+        try fileManager.createDirectory(at: photos, withIntermediateDirectories: true)
+        try Data("image".utf8).write(to: imageURL)
+        defer { try? fileManager.removeItem(at: root) }
+
+        let folder = makeLinkedFolder(url: photos)
+        let store = LibraryIndexStore(
+            persistenceURL: persistenceURL,
+            watchesFileSystem: false
+        )
+        store.configure(folders: [folder])
+        await store.reconcile(folderID: folder.id)
+        XCTAssertEqual(store.files(for: [folder.id]).map(\.url), [imageURL])
+
+        store.testWillScan = {
+            store.remove(urls: [imageURL])
+            store.testWillScan = nil
+        }
+        await store.reconcile(folderID: folder.id)
+
+        XCTAssertEqual(store.files(for: [folder.id]), [])
+        XCTAssertTrue(fileManager.fileExists(atPath: imageURL.path))
+    }
+
+    @MainActor
+    func testLibraryIndexKeepsCachedEntriesWhenFolderIsUnavailable() async throws {
+        let fileManager = FileManager.default
+        let root = fileManager.temporaryDirectory
+            .appendingPathComponent("microfiche-index-offline-\(UUID().uuidString)")
+        let photos = root.appendingPathComponent("Photos", isDirectory: true)
+        let persistenceURL = root.appendingPathComponent("library-index.json")
+        let imageURL = photos.appendingPathComponent("cached.jpg")
+        try fileManager.createDirectory(at: photos, withIntermediateDirectories: true)
+        try Data("image".utf8).write(to: imageURL)
+        defer { try? fileManager.removeItem(at: root) }
+
+        let folderID = UUID()
+        let available = makeLinkedFolder(id: folderID, url: photos)
+        let store = LibraryIndexStore(
+            persistenceURL: persistenceURL,
+            watchesFileSystem: false
+        )
+        store.configure(folders: [available])
+        await store.reconcile(folderID: folderID)
+        XCTAssertEqual(store.files(for: [folderID]).map(\.name), ["cached.jpg"])
+
+        let unavailable = makeLinkedFolder(
+            id: folderID,
+            url: photos,
+            isAvailable: false
+        )
+        try fileManager.removeItem(at: photos)
+        store.configure(folders: [unavailable])
+        await store.reconcileAll()
+
+        XCTAssertEqual(store.files(for: [folderID]).map(\.name), ["cached.jpg"])
+
+        try fileManager.createDirectory(at: photos, withIntermediateDirectories: true)
+        let restoredImage = photos.appendingPathComponent("restored.jpg")
+        try Data("restored".utf8).write(to: restoredImage)
+        store.configure(folders: [available])
+        await store.reconcile(folderID: folderID)
+
+        XCTAssertEqual(store.files(for: [folderID]).map(\.name), ["restored.jpg"])
+    }
+
+    func testLibraryIndexScannerCreateAndDeleteAreIdempotent() throws {
+        let fileManager = FileManager.default
+        let root = fileManager.temporaryDirectory
+            .appendingPathComponent("microfiche-index-events-\(UUID().uuidString)")
+        let created = root.appendingPathComponent("created.jpg")
+        let deleted = root.appendingPathComponent("deleted.jpg")
+        try fileManager.createDirectory(at: root, withIntermediateDirectories: true)
+        try Data("deleted".utf8).write(to: deleted)
+        defer { try? fileManager.removeItem(at: root) }
+
+        let initial = LibraryIndexScanner.scan(root: root)
+        XCTAssertEqual(Set(initial.map(\.path)), [deleted.path])
+
+        try Data("created".utf8).write(to: created)
+        try fileManager.removeItem(at: deleted)
+
+        let firstApply = LibraryIndexScanner.applying(
+            changedPaths: [created.path, deleted.path],
+            to: initial,
+            under: root
+        )
+        let secondApply = LibraryIndexScanner.applying(
+            changedPaths: [created.path, deleted.path],
+            to: firstApply,
+            under: root
+        )
+
+        XCTAssertEqual(Set(firstApply.map(\.path)), [created.path])
+        XCTAssertEqual(Set(secondApply.map(\.path)), [created.path])
+    }
+
+    private func makeLinkedFolder(
+        id: UUID = UUID(),
+        url: URL,
+        resolvedURL: URL? = nil,
+        isAvailable: Bool = true
+    ) -> LinkedLibraryFolder {
         LinkedLibraryFolder(
-            id: UUID(),
+            id: id,
             name: url.lastPathComponent,
             originalPath: url.path,
             volumeIdentifier: nil,
             volumeName: nil,
             isExternal: false,
             addedAt: .now,
-            resolvedURL: url
+            resolvedURL: isAvailable ? (resolvedURL ?? url) : nil
         )
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- PCD-25 (persistent live library index) already landed in [#15](https://github.com/davidhoang/microfiche/pull/15)
- Add unit tests for the remaining acceptance criteria: stale reconcile cancellation, cached entries while a folder is unavailable, reconnect after the folder returns, repeated no-op reconciles, and idempotent create/delete index events
- DEBUG-only `testWillScan` seam lets a local mutation win over an in-flight scan without depending on timing

## Test plan
- [ ] `testLibraryIndexLoadsCachedEntriesBeforeReconcile`
- [ ] `testLibraryIndexReconcileAddsRemovesAndFiltersFiles`
- [ ] `testLibraryIndexScannerAppliesChangedSubtreeIncrementally`
- [ ] `testLibraryIndexLocalRenameUpdatesAndPersistsEntry`
- [ ] `testLibraryIndexRepeatedReconcileDoesNotReplaceUnchangedState`
- [ ] `testLibraryIndexCancelsStaleReconcileAfterLocalMutation`
- [ ] `testLibraryIndexKeepsCachedEntriesWhenFolderIsUnavailable`
- [ ] `testLibraryIndexScannerCreateAndDeleteAreIdempotent`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a02ced-5fa9-7635-af78-4e6e4b5a2f80?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a02ced-5fa9-7635-af78-4e6e4b5a2f80&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

