### PR TITLE
PCD-29: Batch metadata editing for multiple images

### DIFF
--- a/Microfiche/ContentView.swift
+++ b/Microfiche/ContentView.swift
@@ -409,9 +409,9 @@ struct ContentView: View {
                 onArchive: handleArchiveRequest(for:)
             )
             .inspector(isPresented: libraryInspectorBinding) {
-                if let focusedImageFile {
-                    ImageMetadataInspectorView(file: focusedImageFile)
-                        .id(focusedImageFile.id)
+                if !selectedImageFiles.isEmpty {
+                    ImageMetadataInspectorView(files: selectedImageFiles)
+                        .id(selectedImageFiles.map(\.id))
                         .frame(maxWidth: .infinity, maxHeight: .infinity)
                         .inspectorColumnWidth(min: 280, ideal: 320, max: 420)
                 }
@@ -473,7 +473,7 @@ struct ContentView: View {
                 } label: {
                     Image(systemName: "sidebar.right")
                 }
-                .disabled(focusedImageFile == nil)
+                .disabled(selectedImageFileIDs.isEmpty)
                 .help(isMetadataInspectorPresented ? "Hide Info" : "Show Info")
                 .accessibilityLabel(isMetadataInspectorPresented ? "Hide inspector" : "Show inspector")
                 .accessibilityIdentifier("inspector.toggle")
@@ -499,6 +499,14 @@ struct ContentView: View {
                 .hideSharedBackgroundIfAvailable()
             }
         }
+    }
+
+    private var selectedImageFiles: [ImageFile] {
+        let visible = displayedImageFiles.filter { selectedImageFileIDs.contains($0.id) }
+        if !visible.isEmpty {
+            return visible
+        }
+        return imageFiles.filter { selectedImageFileIDs.contains($0.id) }
     }
 
     private var focusedImageFile: ImageFile? {
@@ -590,11 +598,11 @@ struct ContentView: View {
         Binding(
             get: {
                 !isImageDetailPresented
-                    && focusedImageFile != nil
+                    && !selectedImageFileIDs.isEmpty
                     && isMetadataInspectorPresented
             },
             set: { isPresented in
-                guard !isImageDetailPresented, focusedImageFile != nil else { return }
+                guard !isImageDetailPresented, !selectedImageFileIDs.isEmpty else { return }
                 isMetadataInspectorPresented = isPresented
             }
         )

--- a/Microfiche/Services/BatchMetadataEditing.swift
+++ b/Microfiche/Services/BatchMetadataEditing.swift
@@ -1,0 +1,253 @@
+//
+//  BatchMetadataEditing.swift
+//  Microfiche
+//
+//  Shared/mixed/empty inspector state and per-file metadata writes
+//  across a multi-image selection.
+//
+
+import Foundation
+
+struct ResolvedImageMetadata: Equatable, Sendable {
+    var label: FinderLabel
+    var tags: [String]
+    var comments: String
+    var whereFrom: String
+}
+
+enum BatchFieldValue<Value: Equatable>: Equatable {
+    case empty
+    case shared(Value)
+    case mixed
+}
+
+struct BatchMetadataSummary: Equatable {
+    var fileCount: Int
+    var label: BatchFieldValue<FinderLabel>
+    var sharedTags: [String]
+    var mixedTags: [String]
+    var comments: BatchFieldValue<String>
+    var whereFrom: BatchFieldValue<String>
+}
+
+enum BatchMetadataOperation: Equatable {
+    case setLabel(FinderLabel)
+    case addTag(String)
+    case removeTag(String)
+    case replaceComments(String)
+    case replaceWhereFrom(String)
+}
+
+struct BatchMetadataFailure: Equatable {
+    var path: String
+    var message: String
+}
+
+struct BatchMetadataWriteResult: Equatable {
+    var succeededPaths: [String]
+    var skippedMissingPaths: [String]
+    var failures: [BatchMetadataFailure]
+    var wasCancelled: Bool
+
+    var errorMessage: String? {
+        if failures.isEmpty {
+            return wasCancelled && succeededPaths.isEmpty
+                ? "Update cancelled."
+                : nil
+        }
+
+        let details = failures
+            .map { "\(URL(fileURLWithPath: $0.path).lastPathComponent): \($0.message)" }
+            .joined(separator: "\n")
+
+        if failures.count == 1, skippedMissingPaths.isEmpty, !wasCancelled {
+            let name = URL(fileURLWithPath: failures[0].path).lastPathComponent
+            return "Couldn’t update \(name): \(failures[0].message)"
+        }
+
+        var prefix = "Updated \(succeededPaths.count)"
+        if !failures.isEmpty {
+            prefix += ", failed \(failures.count)"
+        }
+        if wasCancelled {
+            prefix += ", cancelled"
+        }
+        return "\(prefix).\n\(details)"
+    }
+}
+
+enum BatchMetadataAggregation {
+    static func resolved(
+        native: NativeFileMetadata,
+        local: ImageMetadata
+    ) -> ResolvedImageMetadata {
+        var label = native.label
+        if label == .none, let migrated = FinderLabel.migrating(from: local.labels) {
+            label = migrated
+        }
+
+        return ResolvedImageMetadata(
+            label: label,
+            tags: native.tagNames.isEmpty ? local.tags : native.tagNames,
+            comments: native.comment.isEmpty ? local.comments : native.comment,
+            whereFrom: local.whereFrom
+        )
+    }
+
+    static func summarize(_ items: [ResolvedImageMetadata]) -> BatchMetadataSummary {
+        guard !items.isEmpty else {
+            return BatchMetadataSummary(
+                fileCount: 0,
+                label: .empty,
+                sharedTags: [],
+                mixedTags: [],
+                comments: .empty,
+                whereFrom: .empty
+            )
+        }
+
+        let labels = items.map(\.label)
+        let comments = items.map {
+            $0.comments.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+        let sources = items.map {
+            $0.whereFrom.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+
+        let tagSets = items.map { Set($0.tags) }
+        let sharedTags = tagSets.reduce(into: tagSets[0]) { $0.formIntersection($1) }
+        let unionTags = tagSets.reduce(into: Set<String>()) { $0.formUnion($1) }
+        let mixedTags = unionTags.subtracting(sharedTags)
+
+        return BatchMetadataSummary(
+            fileCount: items.count,
+            label: reduce(labels, isEmpty: { $0 == .none }),
+            sharedTags: sharedTags.sorted { $0.localizedStandardCompare($1) == .orderedAscending },
+            mixedTags: mixedTags.sorted { $0.localizedStandardCompare($1) == .orderedAscending },
+            comments: reduce(comments, isEmpty: { $0.isEmpty }),
+            whereFrom: reduce(sources, isEmpty: { $0.isEmpty })
+        )
+    }
+
+    private static func reduce<Value: Equatable>(
+        _ values: [Value],
+        isEmpty: (Value) -> Bool
+    ) -> BatchFieldValue<Value> {
+        guard let first = values.first else { return .empty }
+        guard values.allSatisfy({ $0 == first }) else { return .mixed }
+        return isEmpty(first) ? .empty : .shared(first)
+    }
+}
+
+@MainActor
+struct BatchMetadataWriter {
+    var loadResolved: (URL) -> ResolvedImageMetadata
+    var save: (ResolvedImageMetadata, URL) throws -> Void
+    var fileExists: (URL) -> Bool
+    var beforeSave: ((URL) -> Void)? = nil
+    var isCancelled: () -> Bool = { Task.isCancelled }
+
+    static func live(store: ImageMetadataStore = .shared) -> BatchMetadataWriter {
+        BatchMetadataWriter(
+            loadResolved: { url in
+                BatchMetadataAggregation.resolved(
+                    native: NativeFileMetadataService.load(from: url),
+                    local: store.metadata(for: url)
+                )
+            },
+            save: { resolved, url in
+                try NativeFileMetadataService.save(
+                    NativeFileMetadata(
+                        label: resolved.label,
+                        tagNames: resolved.tags,
+                        comment: resolved.comments
+                    ),
+                    for: url
+                )
+                store.save(
+                    ImageMetadata(
+                        tags: resolved.tags,
+                        labels: [],
+                        comments: resolved.comments,
+                        whereFrom: resolved.whereFrom
+                    ),
+                    for: url
+                )
+            },
+            fileExists: { FileManager.default.fileExists(atPath: $0.path) }
+        )
+    }
+
+    func apply(
+        _ operation: BatchMetadataOperation,
+        to urls: [URL]
+    ) async -> BatchMetadataWriteResult {
+        var result = BatchMetadataWriteResult(
+            succeededPaths: [],
+            skippedMissingPaths: [],
+            failures: [],
+            wasCancelled: false
+        )
+
+        for url in urls {
+            if isCancelled() {
+                result.wasCancelled = true
+                break
+            }
+
+            let path = ImageIdentity.normalizedPath(for: url)
+            guard fileExists(url) else {
+                result.skippedMissingPaths.append(path)
+                continue
+            }
+
+            var resolved = loadResolved(url)
+            apply(operation, to: &resolved)
+            beforeSave?(url)
+
+            if isCancelled() {
+                result.wasCancelled = true
+                break
+            }
+
+            do {
+                try save(resolved, url)
+                result.succeededPaths.append(path)
+            } catch {
+                result.failures.append(
+                    BatchMetadataFailure(path: path, message: error.localizedDescription)
+                )
+            }
+        }
+
+        if isCancelled() {
+            result.wasCancelled = true
+        }
+
+        return result
+    }
+
+    private func apply(
+        _ operation: BatchMetadataOperation,
+        to resolved: inout ResolvedImageMetadata
+    ) {
+        switch operation {
+        case .setLabel(let label):
+            resolved.label = label
+        case .addTag(let tag):
+            let trimmed = tag.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty,
+                  !resolved.tags.contains(where: { $0.caseInsensitiveCompare(trimmed) == .orderedSame })
+            else { return }
+            resolved.tags.append(trimmed)
+        case .removeTag(let tag):
+            resolved.tags.removeAll {
+                $0.caseInsensitiveCompare(tag) == .orderedSame
+            }
+        case .replaceComments(let comments):
+            resolved.comments = comments.trimmingCharacters(in: .whitespacesAndNewlines)
+        case .replaceWhereFrom(let whereFrom):
+            resolved.whereFrom = whereFrom.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+    }
+}

--- a/Microfiche/Views/ImageDetailView.swift
+++ b/Microfiche/Views/ImageDetailView.swift
@@ -22,7 +22,7 @@ struct ImageDetailView: View {
     var body: some View {
         extendedImageCanvas
             .inspector(isPresented: $isMetadataPresented) {
-                ImageMetadataInspectorView(file: file)
+                ImageMetadataInspectorView(files: [file])
                     .id(file.id)
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
                     .inspectorColumnWidth(min: 280, ideal: 320, max: 420)
@@ -127,95 +127,179 @@ struct ImageDetailView: View {
 // MARK: - Metadata Inspector
 
 struct ImageMetadataInspectorView: View {
-    let file: ImageFile
+    let files: [ImageFile]
 
-    @State private var finderLabel: FinderLabel = .none
+    @State private var summary = BatchMetadataSummary(
+        fileCount: 0,
+        label: .empty,
+        sharedTags: [],
+        mixedTags: [],
+        comments: .empty,
+        whereFrom: .empty
+    )
     @State private var tags: [String] = []
+    @State private var mixedTags: [String] = []
     @State private var comments = ""
     @State private var whereFrom = ""
+    @State private var commentsDraft = ""
+    @State private var whereFromDraft = ""
     @State private var isEditingTags = false
     @State private var isEditingComments = false
     @State private var isEditingWhereFrom = false
     @State private var newTag = ""
     @State private var saveError: String?
+    @State private var isSaving = false
+    @State private var writeTask: Task<Void, Never>?
+    @State private var writeGeneration = UUID()
     @State private var technicalMetadata = PhotoTechnicalMetadataLoadState()
     @State private var technicalMetadataReloadID = UUID()
+
+    private var file: ImageFile? { files.count == 1 ? files.first : nil }
+    private var isBatch: Bool { files.count > 1 }
+    private var selectionSignature: [UUID] { files.map(\.id) }
 
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 22) {
                 headerSection
 
-                FinderLabelPicker(selection: finderLabel) { label in
-                    applyFinderLabel(label)
+                FinderLabelPicker(selection: selectedLabel) { label in
+                    apply(.setLabel(label))
                 }
+                .disabled(isSaving)
 
                 EditableChipSection(
                     title: "Tags",
-                    subtitle: "Finder tags",
+                    subtitle: isBatch ? "Finder tags across \(files.count) images" : "Finder tags",
                     itemName: "tag",
                     items: $tags,
+                    mixedItems: mixedTags,
                     isEditing: $isEditingTags,
                     newItem: $newTag,
                     chipColor: Color.accentColor.opacity(0.16),
-                    onSave: saveMetadata
+                    onSave: {
+                        // Single-file chip edits write immediately via add/remove hooks.
+                    },
+                    onAdd: { tag in
+                        apply(.addTag(tag))
+                    },
+                    onRemove: { tag in
+                        apply(.removeTag(tag))
+                    }
                 )
+                .disabled(isSaving)
 
-                editableTextSection(
+                replaceableTextSection(
                     title: "Comments",
                     subtitle: "Finder comments",
                     placeholder: "No comments",
-                    text: $comments,
+                    field: summary.comments,
+                    displayed: comments,
+                    draft: $commentsDraft,
                     isEditing: $isEditingComments,
-                    isMultiline: true
+                    isMultiline: true,
+                    replaceIdentifier: "inspector.replace-comments",
+                    onReplace: { apply(.replaceComments($0)) }
                 )
 
-                editableTextSection(
+                replaceableTextSection(
                     title: "Where From",
                     subtitle: "Stored in Microfiche",
                     placeholder: "No source specified",
-                    text: $whereFrom,
+                    field: summary.whereFrom,
+                    displayed: whereFrom,
+                    draft: $whereFromDraft,
                     isEditing: $isEditingWhereFrom,
-                    isMultiline: false
+                    isMultiline: false,
+                    replaceIdentifier: "inspector.replace-where-from",
+                    onReplace: { apply(.replaceWhereFrom($0)) }
                 )
 
-                fileInfoSection
+                if isSaving {
+                    HStack(spacing: 8) {
+                        ProgressView()
+                            .controlSize(.small)
+                        Text("Updating \(files.count) images…")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                        Spacer()
+                        Button("Cancel") {
+                            writeTask?.cancel()
+                        }
+                        .controlSize(.small)
+                        .accessibilityIdentifier("inspector.cancel-write")
+                    }
+                }
 
-                technicalMetadataSection
+                if !isBatch {
+                    fileInfoSection
+                    technicalMetadataSection
+                }
 
                 if let saveError {
                     Text(saveError)
                         .font(.caption)
                         .foregroundStyle(.red)
                         .textSelection(.enabled)
+                        .accessibilityIdentifier("inspector.save-error")
                 }
             }
             .padding(20)
         }
-        .task(id: file.id) {
+        .task(id: selectionSignature) {
             loadMetadata()
         }
         .task(id: technicalMetadataReloadID) {
             await loadTechnicalMetadata()
         }
         .onDisappear {
-            saveMetadata()
+            writeTask?.cancel()
+            guard !isBatch else { return }
+            let urls = files.map(\.url)
+            let commentsToSave = isEditingComments ? commentsDraft : comments
+            let sourceToSave = isEditingWhereFrom ? whereFromDraft : whereFrom
+            Task { @MainActor in
+                let writer = BatchMetadataWriter.live()
+                _ = await writer.apply(.replaceComments(commentsToSave), to: urls)
+                _ = await writer.apply(.replaceWhereFrom(sourceToSave), to: urls)
+            }
         }
         .microficheInspectorContentChrome()
     }
 
+    private var selectedLabel: FinderLabel? {
+        switch summary.label {
+        case .empty:
+            return .none
+        case .shared(let label):
+            return label
+        case .mixed:
+            return nil
+        }
+    }
+
     private var headerSection: some View {
         VStack(alignment: .leading, spacing: 4) {
-            Text(file.name)
-                .font(.system(size: 15, weight: .semibold))
-                .lineLimit(2)
-                .textSelection(.enabled)
+            if let file {
+                Text(file.name)
+                    .font(.system(size: 15, weight: .semibold))
+                    .lineLimit(2)
+                    .textSelection(.enabled)
 
-            Text(file.url.deletingLastPathComponent().path)
-                .font(.caption)
-                .foregroundStyle(.secondary)
-                .lineLimit(2)
-                .textSelection(.enabled)
+                Text(file.url.deletingLastPathComponent().path)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(2)
+                    .textSelection(.enabled)
+            } else {
+                Text("\(files.count) images selected")
+                    .font(.system(size: 15, weight: .semibold))
+                    .accessibilityIdentifier("inspector.selection-summary")
+
+                Text("Shared values apply to every selected image. Mixed tags can be removed from the images that have them.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
         }
     }
 
@@ -224,17 +308,19 @@ struct ImageMetadataInspectorView: View {
             Text("File Info")
                 .font(.headline)
 
-            VStack(alignment: .leading, spacing: 6) {
-                InfoRow(label: "Type", value: file.url.pathExtension.uppercased())
+            if let file {
+                VStack(alignment: .leading, spacing: 6) {
+                    InfoRow(label: "Type", value: file.url.pathExtension.uppercased())
 
-                if let fileSize = file.url.formattedFileSize() {
-                    InfoRow(label: "Size", value: fileSize)
-                }
-                if let creationDate = file.url.formattedCreationDate() {
-                    InfoRow(label: "Created", value: creationDate)
-                }
-                if let modificationDate = file.url.formattedModificationDate() {
-                    InfoRow(label: "Modified", value: modificationDate)
+                    if let fileSize = file.url.formattedFileSize() {
+                        InfoRow(label: "Size", value: fileSize)
+                    }
+                    if let creationDate = file.url.formattedCreationDate() {
+                        InfoRow(label: "Created", value: creationDate)
+                    }
+                    if let modificationDate = file.url.formattedModificationDate() {
+                        InfoRow(label: "Modified", value: modificationDate)
+                    }
                 }
             }
         }
@@ -284,13 +370,17 @@ struct ImageMetadataInspectorView: View {
     }
 
     @ViewBuilder
-    private func editableTextSection(
+    private func replaceableTextSection(
         title: String,
         subtitle: String? = nil,
         placeholder: String,
-        text: Binding<String>,
+        field: BatchFieldValue<String>,
+        displayed: String,
+        draft: Binding<String>,
         isEditing: Binding<Bool>,
-        isMultiline: Bool
+        isMultiline: Bool,
+        replaceIdentifier: String,
+        onReplace: @escaping (String) -> Void
     ) -> some View {
         VStack(alignment: .leading, spacing: 8) {
             HStack(alignment: .firstTextBaseline) {
@@ -305,62 +395,125 @@ struct ImageMetadataInspectorView: View {
                 }
                 Spacer()
                 Button {
-                    isEditing.wrappedValue.toggle()
-                    if !isEditing.wrappedValue { saveMetadata() }
+                    if isEditing.wrappedValue {
+                        onReplace(draft.wrappedValue)
+                        isEditing.wrappedValue = false
+                    } else {
+                        draft.wrappedValue = displayed
+                        isEditing.wrappedValue = true
+                    }
                 } label: {
-                    Image(systemName: isEditing.wrappedValue ? "checkmark" : "pencil")
+                    Image(systemName: isEditing.wrappedValue ? "checkmark" : (isBatch ? "square.and.pencil" : "pencil"))
                 }
                 .buttonStyle(.borderless)
-                .help(isEditing.wrappedValue ? "Done" : "Edit \(title)")
+                .disabled(isSaving)
+                .help(isEditing.wrappedValue ? "Replace \(title)" : "Replace \(title)")
+                .accessibilityIdentifier(replaceIdentifier)
             }
 
             if isEditing.wrappedValue {
                 if isMultiline {
-                    TextEditor(text: text)
+                    TextEditor(text: draft)
                         .frame(minHeight: 88)
                         .overlay {
                             RoundedRectangle(cornerRadius: 6)
                                 .strokeBorder(Color(NSColor.separatorColor))
                         }
                 } else {
-                    TextField("Enter source", text: text)
+                    TextField("Enter source", text: draft)
                         .textFieldStyle(.roundedBorder)
-                        .onSubmit { saveMetadata() }
+                        .onSubmit {
+                            onReplace(draft.wrappedValue)
+                            isEditing.wrappedValue = false
+                        }
                 }
+
+                if isBatch {
+                    Text("This replaces \(title.lowercased()) on every selected image.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                Button("Cancel") {
+                    isEditing.wrappedValue = false
+                    draft.wrappedValue = displayed
+                }
+                .buttonStyle(.borderless)
+                .controlSize(.small)
             } else {
-                Text(text.wrappedValue.isEmpty ? placeholder : text.wrappedValue)
-                    .foregroundStyle(text.wrappedValue.isEmpty ? .secondary : .primary)
-                    .italic(text.wrappedValue.isEmpty)
+                Text(displayText(for: field, placeholder: placeholder))
+                    .foregroundStyle(fieldDisplayIsPlaceholder(field) ? .secondary : .primary)
+                    .italic(fieldDisplayIsPlaceholder(field))
                     .textSelection(.enabled)
             }
         }
     }
 
+    private func displayText(
+        for field: BatchFieldValue<String>,
+        placeholder: String
+    ) -> String {
+        switch field {
+        case .empty:
+            return placeholder
+        case .shared(let value):
+            return value
+        case .mixed:
+            return "Multiple values"
+        }
+    }
+
+    private func fieldDisplayIsPlaceholder(_ field: BatchFieldValue<String>) -> Bool {
+        switch field {
+        case .empty, .mixed:
+            return true
+        case .shared:
+            return false
+        }
+    }
+
     private func loadMetadata() {
+        writeTask?.cancel()
         isEditingTags = false
         isEditingComments = false
         isEditingWhereFrom = false
         newTag = ""
         saveError = nil
+        isSaving = false
 
-        let local = ImageMetadataStore.shared.metadata(for: file.url)
-        let native = NativeFileMetadataService.load(from: file.url)
+        let resolved = files.map { file in
+            BatchMetadataAggregation.resolved(
+                native: NativeFileMetadataService.load(from: file.url),
+                local: ImageMetadataStore.shared.metadata(for: file.url)
+            )
+        }
+        let next = BatchMetadataAggregation.summarize(resolved)
+        summary = next
+        tags = next.sharedTags
+        mixedTags = next.mixedTags
+        comments = {
+            if case .shared(let value) = next.comments { return value }
+            return ""
+        }()
+        whereFrom = {
+            if case .shared(let value) = next.whereFrom { return value }
+            return ""
+        }()
+        commentsDraft = comments
+        whereFromDraft = whereFrom
 
-        finderLabel = native.label
-        tags = native.tagNames.isEmpty ? local.tags : native.tagNames
-        comments = native.comment.isEmpty ? local.comments : native.comment
-        whereFrom = local.whereFrom
-
-        if native.label == .none,
-           let migrated = FinderLabel.migrating(from: local.labels) {
-            applyFinderLabel(migrated)
-        } else if !local.labels.isEmpty {
-            // Drop obsolete free-text labels once native labels own this field.
-            persistLocalMetadata()
+        if files.count == 1,
+           let file = files.first,
+           NativeFileMetadataService.load(from: file.url).label == .none,
+           let migrated = FinderLabel.migrating(
+            from: ImageMetadataStore.shared.metadata(for: file.url).labels
+           ) {
+            apply(.setLabel(migrated))
         }
     }
 
     private func loadTechnicalMetadata() async {
+        guard let file else { return }
         let requestID = technicalMetadata.beginLoading()
         let requestedURL = file.url
         let outcome = await Task.detached(priority: .utility) {
@@ -380,53 +533,29 @@ struct ImageMetadataInspectorView: View {
         }
     }
 
-    private func applyFinderLabel(_ label: FinderLabel) {
-        finderLabel = label
-        do {
-            try NativeFileMetadataService.setLabel(label, for: file.url)
-            persistLocalMetadata()
-            saveError = nil
-        } catch {
-            saveError = "Couldn’t update Finder label: \(error.localizedDescription)"
-        }
-    }
+    private func apply(_ operation: BatchMetadataOperation) {
+        let urls = files.map(\.url)
+        let generation = UUID()
+        writeGeneration = generation
+        writeTask?.cancel()
 
-    private func saveMetadata() {
-        do {
-            try NativeFileMetadataService.save(
-                NativeFileMetadata(
-                    label: finderLabel,
-                    tagNames: tags,
-                    comment: comments
-                ),
-                for: file.url
-            )
-            persistLocalMetadata()
-            saveError = nil
-        } catch {
-            // Keep a local copy even when the file system rejects native writes.
-            persistLocalMetadata()
-            saveError = "Couldn’t write Finder metadata: \(error.localizedDescription)"
+        let task = Task { @MainActor in
+            isSaving = urls.count > 1
+            let result = await BatchMetadataWriter.live().apply(operation, to: urls)
+            guard writeGeneration == generation else { return }
+            isSaving = false
+            writeTask = nil
+            loadMetadata()
+            saveError = result.errorMessage
         }
-    }
-
-    private func persistLocalMetadata() {
-        ImageMetadataStore.shared.save(
-            ImageMetadata(
-                tags: tags,
-                labels: [],
-                comments: comments,
-                whereFrom: whereFrom
-            ),
-            for: file.url
-        )
+        writeTask = task
     }
 }
 
 // MARK: - Finder Label Picker
 
 struct FinderLabelPicker: View {
-    let selection: FinderLabel
+    let selection: FinderLabel?
     let onSelect: (FinderLabel) -> Void
 
     var body: some View {
@@ -449,9 +578,20 @@ struct FinderLabelPicker: View {
             .accessibilityElement(children: .contain)
             .accessibilityLabel("Finder label")
 
-            Text(selection == .none ? "No label" : selection.displayName)
+            Text(labelCaption)
                 .font(.caption)
                 .foregroundStyle(.secondary)
+        }
+    }
+
+    private var labelCaption: String {
+        switch selection {
+        case nil:
+            return "Multiple labels"
+        case .some(.none):
+            return "No label"
+        case .some(let label):
+            return label.displayName
         }
     }
 
@@ -503,10 +643,13 @@ struct EditableChipSection: View {
     var subtitle: String? = nil
     let itemName: String
     @Binding var items: [String]
+    var mixedItems: [String] = []
     @Binding var isEditing: Bool
     @Binding var newItem: String
     let chipColor: Color
     let onSave: () -> Void
+    var onAdd: ((String) -> Void)? = nil
+    var onRemove: ((String) -> Void)? = nil
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
@@ -541,35 +684,58 @@ struct EditableChipSection: View {
                 }
             }
 
-            if items.isEmpty {
+            if items.isEmpty, mixedItems.isEmpty {
                 Text("No \(title.lowercased())")
                     .foregroundStyle(.secondary)
                     .italic()
             } else {
                 LazyVGrid(columns: [GridItem(.adaptive(minimum: 88))], spacing: 8) {
                     ForEach(items, id: \.self) { item in
-                        HStack(spacing: 4) {
-                            Text(item)
-                                .lineLimit(1)
-                            Spacer(minLength: 2)
-                            if isEditing {
-                                Button {
-                                    items.removeAll { $0 == item }
-                                    onSave()
-                                } label: {
-                                    Image(systemName: "xmark.circle.fill")
-                                        .foregroundStyle(.secondary)
-                                }
-                                .buttonStyle(.plain)
-                            }
-                        }
-                        .padding(.horizontal, 8)
-                        .padding(.vertical, 5)
-                        .background(chipColor, in: RoundedRectangle(cornerRadius: 7))
+                        chip(item, mixed: false)
+                    }
+                    ForEach(mixedItems, id: \.self) { item in
+                        chip(item, mixed: true)
                     }
                 }
             }
         }
+    }
+
+    private func chip(_ item: String, mixed: Bool) -> some View {
+        HStack(spacing: 4) {
+            Text(item)
+                .lineLimit(1)
+            Spacer(minLength: 2)
+            if isEditing {
+                Button {
+                    items.removeAll { $0 == item }
+                    if let onRemove {
+                        onRemove(item)
+                    } else {
+                        onSave()
+                    }
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .foregroundStyle(.secondary)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Remove \(item)")
+            }
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 5)
+        .background(
+            (mixed ? Color.secondary.opacity(0.14) : chipColor),
+            in: RoundedRectangle(cornerRadius: 7)
+        )
+        .overlay {
+            if mixed {
+                RoundedRectangle(cornerRadius: 7)
+                    .strokeBorder(style: StrokeStyle(lineWidth: 1, dash: [3, 2]))
+                    .foregroundStyle(.tertiary)
+            }
+        }
+        .accessibilityLabel(mixed ? "\(item), mixed" : item)
     }
 
     private func addItem() {
@@ -577,7 +743,11 @@ struct EditableChipSection: View {
         guard !value.isEmpty, !items.contains(value) else { return }
         items.append(value)
         newItem = ""
-        onSave()
+        if let onAdd {
+            onAdd(value)
+        } else {
+            onSave()
+        }
     }
 }
 

--- a/MicroficheTests/MicroficheTests.swift
+++ b/MicroficheTests/MicroficheTests.swift
@@ -1114,6 +1114,134 @@ final class MicroficheTests: XCTestCase {
         XCTAssertTrue(cleared.comment.isEmpty)
     }
 
+    func testBatchMetadataSummaryDetectsSharedMixedAndEmptyValues() {
+        let empty = ResolvedImageMetadata(
+            label: .none, tags: [], comments: "", whereFrom: ""
+        )
+        let red = ResolvedImageMetadata(
+            label: .red,
+            tags: ["Travel", "Keep"],
+            comments: "Golden hour",
+            whereFrom: "Seattle"
+        )
+        let blue = ResolvedImageMetadata(
+            label: .blue,
+            tags: ["Travel"],
+            comments: "Golden hour",
+            whereFrom: "Portland"
+        )
+
+        let one = BatchMetadataAggregation.summarize([red])
+        XCTAssertEqual(one.fileCount, 1)
+        XCTAssertEqual(one.label, .shared(.red))
+        XCTAssertEqual(one.sharedTags, ["Keep", "Travel"])
+        XCTAssertTrue(one.mixedTags.isEmpty)
+        XCTAssertEqual(one.comments, .shared("Golden hour"))
+        XCTAssertEqual(one.whereFrom, .shared("Seattle"))
+
+        let mixed = BatchMetadataAggregation.summarize([red, blue])
+        XCTAssertEqual(mixed.label, .mixed)
+        XCTAssertEqual(mixed.sharedTags, ["Travel"])
+        XCTAssertEqual(mixed.mixedTags, ["Keep"])
+        XCTAssertEqual(mixed.comments, .shared("Golden hour"))
+        XCTAssertEqual(mixed.whereFrom, .mixed)
+
+        let empties = BatchMetadataAggregation.summarize([empty, empty])
+        XCTAssertEqual(empties.label, .empty)
+        XCTAssertTrue(empties.sharedTags.isEmpty)
+        XCTAssertEqual(empties.comments, .empty)
+        XCTAssertEqual(empties.whereFrom, .empty)
+    }
+
+    @MainActor
+    func testBatchMetadataWriterCoversSingleMultipleRepeatedPartialFailureAndCancellation() async throws {
+        enum WriteError: Error { case boom }
+
+        let first = URL(fileURLWithPath: "/tmp/batch-a.jpg")
+        let second = URL(fileURLWithPath: "/tmp/batch-b.jpg")
+        let missing = URL(fileURLWithPath: "/tmp/batch-missing.jpg")
+        let firstPath = ImageIdentity.normalizedPath(for: first)
+        let secondPath = ImageIdentity.normalizedPath(for: second)
+
+        var records: [String: ResolvedImageMetadata] = [
+            firstPath: ResolvedImageMetadata(
+                label: .none, tags: ["Keep"], comments: "One", whereFrom: "A"
+            ),
+            secondPath: ResolvedImageMetadata(
+                label: .red, tags: ["Travel"], comments: "Two", whereFrom: "B"
+            )
+        ]
+        var failing = Set<String>()
+        var missingPaths = Set<String>()
+        var writer = BatchMetadataWriter(
+            loadResolved: { url in
+                records[ImageIdentity.normalizedPath(for: url)]
+                    ?? ResolvedImageMetadata(
+                        label: .none, tags: [], comments: "", whereFrom: ""
+                    )
+            },
+            save: { resolved, url in
+                let path = ImageIdentity.normalizedPath(for: url)
+                if failing.contains(path) {
+                    throw WriteError.boom
+                }
+                records[path] = resolved
+            },
+            fileExists: { url in
+                !missingPaths.contains(ImageIdentity.normalizedPath(for: url))
+            }
+        )
+
+        let single = await writer.apply(.setLabel(.blue), to: [first])
+        XCTAssertEqual(single.succeededPaths, [firstPath])
+        XCTAssertEqual(records[firstPath]?.label, .blue)
+
+        let added = await writer.apply(.addTag("Travel"), to: [first, second])
+        XCTAssertEqual(Set(added.succeededPaths), [firstPath, secondPath])
+        XCTAssertEqual(records[firstPath]?.tags.sorted(), ["Keep", "Travel"])
+        XCTAssertEqual(records[secondPath]?.tags, ["Travel"])
+
+        let repeated = await writer.apply(.addTag("Travel"), to: [first, second])
+        XCTAssertEqual(Set(repeated.succeededPaths), [firstPath, secondPath])
+        XCTAssertEqual(records[firstPath]?.tags.sorted(), ["Keep", "Travel"])
+
+        let removed = await writer.apply(.removeTag("Keep"), to: [first, second])
+        XCTAssertEqual(Set(removed.succeededPaths), [firstPath, secondPath])
+        XCTAssertEqual(records[firstPath]?.tags, ["Travel"])
+        XCTAssertEqual(records[secondPath]?.tags, ["Travel"])
+
+        let replaced = await writer.apply(.replaceComments("Shared"), to: [first, second])
+        XCTAssertEqual(replaced.succeededPaths.count, 2)
+        XCTAssertEqual(records[firstPath]?.comments, "Shared")
+        XCTAssertEqual(records[secondPath]?.comments, "Shared")
+        XCTAssertEqual(records[firstPath]?.whereFrom, "A")
+
+        failing = [secondPath]
+        let partial = await writer.apply(.replaceWhereFrom("Studio"), to: [first, second])
+        XCTAssertEqual(partial.succeededPaths, [firstPath])
+        XCTAssertEqual(partial.failures.map(\.path), [secondPath])
+        XCTAssertEqual(records[firstPath]?.whereFrom, "Studio")
+        XCTAssertEqual(records[secondPath]?.whereFrom, "B")
+        XCTAssertNotNil(partial.errorMessage)
+
+        missingPaths = [ImageIdentity.normalizedPath(for: missing)]
+        let skipped = await writer.apply(.setLabel(.green), to: [first, missing])
+        XCTAssertEqual(skipped.succeededPaths, [firstPath])
+        XCTAssertEqual(skipped.skippedMissingPaths, [ImageIdentity.normalizedPath(for: missing)])
+        XCTAssertEqual(records[firstPath]?.label, .green)
+
+        var cancelRequested = false
+        writer.beforeSave = { _ in
+            cancelRequested = true
+        }
+        writer.isCancelled = { cancelRequested }
+        let cancelled = await writer.apply(.setLabel(.orange), to: [first, second])
+        XCTAssertTrue(cancelled.wasCancelled)
+        XCTAssertTrue(cancelled.succeededPaths.isEmpty)
+        XCTAssertEqual(records[firstPath]?.label, .green)
+        XCTAssertEqual(records[secondPath]?.label, .red)
+    }
+
     func testPhotoMetadataReaderReadsPNGDimensionsAndReportsMissingFiles() throws {
         let pngData = Data(base64Encoded:
             "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
PCD-29: batch metadata editing for a multi-image review set.

- Inspector summarizes mixed, shared, and empty Finder labels, tags, comments, and source
- Set or clear a label and add or remove tags across the current selection
- Comments and Where From require an explicit Replace action so mixed values are not overwritten by typing
- Writes keep Finder-native metadata and `ImageMetadataStore` in sync, report per-file failures, skip missing files, and can be cancelled
- Library inspector follows the current selection set; file info and technical EXIF stay single-image only

## Test plan
- [ ] Select one image: label, tags, comments, and source still edit as before
- [ ] Command-click a second image: inspector shows “N images selected” and mixed vs shared tags/labels
- [ ] Set a label and clear it; add a tag; remove a shared tag and a mixed tag
- [ ] Replace comments and source; cancel a replace without writing
- [ ] Delete one selected file while the inspector is open; remaining selection stays
- [ ] Unit tests: `testBatchMetadataSummaryDetectsSharedMixedAndEmptyValues`, `testBatchMetadataWriterCoversSingleMultipleRepeatedPartialFailureAndCancellation`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a02ced-5fa9-7635-af78-4e6e4b5a2f80?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a02ced-5fa9-7635-af78-4e6e4b5a2f80&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

