### PR TITLE
PCD-28/26: Harden storage recovery and UI interaction coverage

### DIFF
--- a/Microfiche/ContentView.swift
+++ b/Microfiche/ContentView.swift
@@ -57,6 +57,36 @@ enum LibraryNavigation {
     }
 }
 
+struct LibraryBrowsingState: Equatable {
+    var selectedIDs: Set<UUID>
+    var focusedID: UUID?
+    var detailID: UUID?
+    var isQuickPreviewPresented: Bool
+}
+
+enum LibraryBrowsingRecovery {
+    static func reconciling(
+        _ state: LibraryBrowsingState,
+        with files: [ImageFile]
+    ) -> LibraryBrowsingState {
+        let availableIDs = Set(files.map(\.id))
+        let focusedID = state.focusedID.flatMap {
+            availableIDs.contains($0) ? $0 : nil
+        }
+        let detailID = state.detailID.flatMap {
+            availableIDs.contains($0) ? $0 : nil
+        }
+        return LibraryBrowsingState(
+            selectedIDs: state.selectedIDs.intersection(availableIDs),
+            focusedID: focusedID,
+            detailID: detailID,
+            isQuickPreviewPresented: focusedID == nil
+                ? false
+                : state.isQuickPreviewPresented
+        )
+    }
+}
+
 extension Notification.Name {
     static let microficheMoveSelectionToArchive = Notification.Name("microficheMoveSelectionToArchive")
 }
@@ -872,15 +902,20 @@ struct ContentView: View {
         }
 
         let nextFiles = libraryIndex.files(for: folderIDs)
-        let nextIDs = Set(nextFiles.map(\.id))
+        let recoveredState = LibraryBrowsingRecovery.reconciling(
+            LibraryBrowsingState(
+                selectedIDs: selectedImageFileIDs,
+                focusedID: focusedImageFileID,
+                detailID: detailImageID,
+                isQuickPreviewPresented: isQuickPreviewPresented
+            ),
+            with: nextFiles
+        )
         imageFiles = nextFiles
-        selectedImageFileIDs.formIntersection(nextIDs)
-
-        if let focusedImageFileID, !nextIDs.contains(focusedImageFileID) {
-            self.focusedImageFileID = nil
-            isQuickPreviewPresented = false
-        }
-        if let detailImageID, !nextIDs.contains(detailImageID) {
+        selectedImageFileIDs = recoveredState.selectedIDs
+        focusedImageFileID = recoveredState.focusedID
+        isQuickPreviewPresented = recoveredState.isQuickPreviewPresented
+        if recoveredState.detailID == nil, detailImageID != nil {
             libraryPath.removeAll()
         }
     }

--- a/Microfiche/ContentView.swift
+++ b/Microfiche/ContentView.swift
@@ -114,7 +114,7 @@ struct ContentView: View {
     @State private var selectedImageFileIDs: Set<UUID> = []
     @State private var focusedImageFileID: UUID?
     @State private var showDeleteAlert: Bool = false
-    @State private var dontAskAgain: Bool = UserDefaults.standard.bool(forKey: "dontAskDeleteConfirm")
+    @State private var dontAskAgain: Bool
     @State private var pendingDeleteFiles: [ImageFile] = []
     @State private var showChooseArchiveAlert = false
     @State private var pendingArchiveFiles: [ImageFile] = []
@@ -124,20 +124,89 @@ struct ContentView: View {
     @State private var gridColumnCount: Int = 1
     @State private var libraryPath: [LibraryRoute] = []
     @State private var contactSheetExportPresentation: ContactSheetExportPresentation?
-    @AppStorage("libraryMetadataInspectorPresented") private var isMetadataInspectorPresented = false
-    @AppStorage("detailMetadataPresented") private var isDetailMetadataPresented = true
-    @AppStorage("librarySidebarCollapsed") private var isLibrarySidebarCollapsed = false
+    @AppStorage private var isMetadataInspectorPresented: Bool
+    @AppStorage private var isDetailMetadataPresented: Bool
+    @AppStorage private var isLibrarySidebarCollapsed: Bool
     @State private var externalDriveNotice: String?
     @State private var searchText = ""
     @State private var selectedFileType = ""
     @State private var selectedTag = ""
-    @AppStorage("lastSelectedLibraryFolderID") private var lastSelectedLibraryFolderID = ""
-    @StateObject private var libraryStorage = LibraryStorage.shared
-    @StateObject private var contactSheetStorage = ContactSheetStorage.shared
-    @StateObject private var userPreferences = UserPreferences.shared
-    @StateObject private var archiveFolderStore = ArchiveFolderStore.shared
-    @StateObject private var libraryIndex = LibraryIndexStore.shared
+    @AppStorage private var lastSelectedLibraryFolderID: String
+    @StateObject private var libraryStorage: LibraryStorage
+    @StateObject private var contactSheetStorage: ContactSheetStorage
+    @StateObject private var userPreferences: UserPreferences
+    @StateObject private var archiveFolderStore: ArchiveFolderStore
+    @StateObject private var libraryIndex: LibraryIndexStore
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    init() {
+        #if DEBUG
+        if ProcessInfo.processInfo.arguments.contains("--ui-testing-fixtures") {
+            let fixture = UITestFixture.make()
+            let defaults = fixture.userPreferences.defaultsStore
+            _selection = State(initialValue: .all)
+            _dontAskAgain = State(
+                initialValue: defaults.bool(forKey: "dontAskDeleteConfirm")
+            )
+            _isMetadataInspectorPresented = AppStorage(
+                wrappedValue: false,
+                "libraryMetadataInspectorPresented",
+                store: defaults
+            )
+            _isDetailMetadataPresented = AppStorage(
+                wrappedValue: true,
+                "detailMetadataPresented",
+                store: defaults
+            )
+            _isLibrarySidebarCollapsed = AppStorage(
+                wrappedValue: false,
+                "librarySidebarCollapsed",
+                store: defaults
+            )
+            _lastSelectedLibraryFolderID = AppStorage(
+                wrappedValue: "",
+                "lastSelectedLibraryFolderID",
+                store: defaults
+            )
+            _libraryStorage = StateObject(wrappedValue: fixture.libraryStorage)
+            _contactSheetStorage = StateObject(wrappedValue: fixture.contactSheetStorage)
+            _userPreferences = StateObject(wrappedValue: fixture.userPreferences)
+            _archiveFolderStore = StateObject(wrappedValue: fixture.archiveFolderStore)
+            _libraryIndex = StateObject(wrappedValue: fixture.libraryIndex)
+            return
+        }
+        #endif
+
+        let defaults = UserDefaults.standard
+        _dontAskAgain = State(
+            initialValue: defaults.bool(forKey: "dontAskDeleteConfirm")
+        )
+        _isMetadataInspectorPresented = AppStorage(
+            wrappedValue: false,
+            "libraryMetadataInspectorPresented",
+            store: defaults
+        )
+        _isDetailMetadataPresented = AppStorage(
+            wrappedValue: true,
+            "detailMetadataPresented",
+            store: defaults
+        )
+        _isLibrarySidebarCollapsed = AppStorage(
+            wrappedValue: false,
+            "librarySidebarCollapsed",
+            store: defaults
+        )
+        _lastSelectedLibraryFolderID = AppStorage(
+            wrappedValue: "",
+            "lastSelectedLibraryFolderID",
+            store: defaults
+        )
+        _libraryStorage = StateObject(wrappedValue: LibraryStorage.shared)
+        _contactSheetStorage = StateObject(wrappedValue: ContactSheetStorage.shared)
+        _userPreferences = StateObject(wrappedValue: UserPreferences.shared)
+        _archiveFolderStore = StateObject(wrappedValue: ArchiveFolderStore.shared)
+        _libraryIndex = StateObject(wrappedValue: LibraryIndexStore.shared)
+    }
 
     private var displayedGridThumbnailSize: CGFloat {
         liveGridThumbnailSize ?? gridThumbnailSize

--- a/Microfiche/ContentView.swift
+++ b/Microfiche/ContentView.swift
@@ -133,8 +133,6 @@ struct ContentView: View {
         static let maximumWidth: CGFloat = 360
     }
 
-    @Environment(\.toggleSidebar) private var toggleSidebar
-
     @State private var selection: Selection?
     @State private var imageFiles: [ImageFile] = []
     @State private var viewMode: ViewMode = .grid
@@ -345,7 +343,10 @@ struct ContentView: View {
                     Button("Move to Trash", role: .destructive) {
                         moveFilesToTrash(pendingDeleteFiles)
                         if dontAskAgain {
-                            UserDefaults.standard.set(true, forKey: "dontAskDeleteConfirm")
+                            userPreferences.defaultsStore.set(
+                                true,
+                                forKey: "dontAskDeleteConfirm"
+                            )
                         }
                     }
                     .keyboardShortcut(.defaultAction)
@@ -525,7 +526,11 @@ struct ContentView: View {
     private var libraryToolbar: some ToolbarContent {
         if !isImageDetailPresented {
             ToolbarItem {
-                Button(action: toggleSidebar) {
+                Button {
+                    withAnimation(MicroficheMotion.transition(reducedMotion: reduceMotion)) {
+                        isLibrarySidebarCollapsed.toggle()
+                    }
+                } label: {
                     Image(systemName: "sidebar.left")
                 }
                 .help("Toggle Sidebar")

--- a/Microfiche/Extensions/URL+iCloud.swift
+++ b/Microfiche/Extensions/URL+iCloud.swift
@@ -10,38 +10,108 @@ enum ICloudItemState: Equatable {
     case current
     case downloading
     case notDownloaded
+    case failed(String)
 
     var needsDownload: Bool {
         self == .downloading || self == .notDownloaded
     }
 }
 
-enum ICloudItemDownloadError: Error {
+enum ICloudItemDownloadError: Error, Equatable, LocalizedError {
     case timedOut
+    case unavailable(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .timedOut:
+            return "The iCloud download timed out."
+        case .unavailable(let message):
+            return message
+        }
+    }
+}
+
+protocol ICloudItemDownloading: Sendable {
+    func state(for url: URL) -> ICloudItemState
+    func requestDownload(for url: URL) throws
+}
+
+struct SystemICloudItemDownloader: ICloudItemDownloading {
+    func state(for url: URL) -> ICloudItemState {
+        url.iCloudItemState
+    }
+
+    func requestDownload(for url: URL) throws {
+        try url.requestICloudDownload()
+    }
 }
 
 actor ICloudItemDownloadCoordinator {
     static let shared = ICloudItemDownloadCoordinator()
 
     private var downloads: [String: Task<Void, Error>] = [:]
+    private let downloader: any ICloudItemDownloading
+    private let maxPollAttempts: Int
+    private let pollInterval: Duration
+    private let sleep: @Sendable (Duration) async throws -> Void
+
+    init(
+        downloader: any ICloudItemDownloading = SystemICloudItemDownloader(),
+        maxPollAttempts: Int = 480,
+        pollInterval: Duration = .milliseconds(250),
+        sleep: @escaping @Sendable (Duration) async throws -> Void = { duration in
+            try await Task.sleep(for: duration)
+        }
+    ) {
+        self.downloader = downloader
+        self.maxPollAttempts = maxPollAttempts
+        self.pollInterval = pollInterval
+        self.sleep = sleep
+    }
 
     func prepareForReading(_ url: URL) async throws {
-        guard url.iCloudItemState.needsDownload else { return }
+        switch downloader.state(for: url) {
+        case .local, .current:
+            return
+        case .failed(let message):
+            throw ICloudItemDownloadError.unavailable(message)
+        case .downloading, .notDownloaded:
+            break
+        }
 
         let key = url.standardizedFileURL.path
         if let download = downloads[key] {
             try await download.value
+            try Task.checkCancellation()
             return
         }
 
+        let downloader = self.downloader
+        let maxPollAttempts = self.maxPollAttempts
+        let pollInterval = self.pollInterval
+        let sleep = self.sleep
         let download = Task {
-            try await url.downloadICloudItemIfNeeded()
+            try downloader.requestDownload(for: url)
+
+            for _ in 0..<maxPollAttempts {
+                try Task.checkCancellation()
+                switch downloader.state(for: url) {
+                case .local, .current:
+                    return
+                case .failed(let message):
+                    throw ICloudItemDownloadError.unavailable(message)
+                case .downloading, .notDownloaded:
+                    try await sleep(pollInterval)
+                }
+            }
+            throw ICloudItemDownloadError.timedOut
         }
         downloads[key] = download
 
         do {
             try await download.value
             downloads[key] = nil
+            try Task.checkCancellation()
         } catch {
             downloads[key] = nil
             throw error
@@ -52,8 +122,15 @@ actor ICloudItemDownloadCoordinator {
 extension URL {
     var iCloudItemState: ICloudItemState {
         guard FileManager.default.isUbiquitousItem(at: self) else { return .local }
-        guard let values = try? resourceValues(forKeys: [.ubiquitousItemDownloadingStatusKey]) else {
+        guard let values = try? resourceValues(forKeys: [
+            .ubiquitousItemDownloadingStatusKey,
+            .ubiquitousItemDownloadingErrorKey
+        ]) else {
             return .downloading
+        }
+
+        if let error = values.ubiquitousItemDownloadingError {
+            return .failed(error.localizedDescription)
         }
 
         switch values.ubiquitousItemDownloadingStatus {
@@ -72,19 +149,6 @@ extension URL {
     }
 
     func downloadICloudItemIfNeeded() async throws {
-        guard iCloudItemState.needsDownload else { return }
-
-        try requestICloudDownload()
-
-        let clock = ContinuousClock()
-        let deadline = clock.now.advanced(by: .seconds(120))
-
-        while iCloudItemState.needsDownload {
-            try Task.checkCancellation()
-            guard clock.now < deadline else {
-                throw ICloudItemDownloadError.timedOut
-            }
-            try await Task.sleep(for: .milliseconds(250))
-        }
+        try await ICloudItemDownloadCoordinator.shared.prepareForReading(self)
     }
 }

--- a/Microfiche/Extensions/URL+iCloud.swift
+++ b/Microfiche/Extensions/URL+iCloud.swift
@@ -70,12 +70,15 @@ actor ICloudItemDownloadCoordinator {
     }
 
     func prepareForReading(_ url: URL) async throws {
-        switch downloader.state(for: url) {
+        let initialState = downloader.state(for: url)
+        let isRetryingFailure: Bool
+        switch initialState {
         case .local, .current:
             return
-        case .failed(let message):
-            throw ICloudItemDownloadError.unavailable(message)
+        case .failed:
+            isRetryingFailure = true
         case .downloading, .notDownloaded:
+            isRetryingFailure = false
             break
         }
 
@@ -93,12 +96,16 @@ actor ICloudItemDownloadCoordinator {
         let download = Task {
             try downloader.requestDownload(for: url)
 
-            for _ in 0..<maxPollAttempts {
+            for attempt in 0..<maxPollAttempts {
                 try Task.checkCancellation()
                 switch downloader.state(for: url) {
                 case .local, .current:
                     return
                 case .failed(let message):
+                    if isRetryingFailure, attempt == 0 {
+                        try await sleep(pollInterval)
+                        continue
+                    }
                     throw ICloudItemDownloadError.unavailable(message)
                 case .downloading, .notDownloaded:
                     try await sleep(pollInterval)

--- a/Microfiche/Services/ImageLoadState.swift
+++ b/Microfiche/Services/ImageLoadState.swift
@@ -10,6 +10,7 @@ enum ImageLoadPhase: Equatable {
     case idle
     case placeholder
     case downloading
+    case retrying
     case loading
     case loaded
     case failed(String)
@@ -37,7 +38,12 @@ struct ImageLoadState: Equatable {
     mutating func begin(for itemState: ICloudItemState) -> UUID {
         let id = UUID()
         requestID = id
-        phase = itemState.needsDownload ? .downloading : .loading
+        switch phase {
+        case .failed, .cancelled:
+            phase = .retrying
+        default:
+            phase = itemState.needsDownload ? .downloading : .loading
+        }
         return id
     }
 
@@ -89,7 +95,14 @@ final class PreviewImageLoadModel: ObservableObject {
     private var url: URL?
 
     func prepare(url: URL) {
-        guard self.url != url || state.phase == .idle else { return }
+        if self.url == url {
+            switch state.phase {
+            case .cancelled, .idle:
+                break
+            default:
+                return
+            }
+        }
         task?.cancel()
         self.url = url
         image = nil

--- a/Microfiche/Services/ImageLoadState.swift
+++ b/Microfiche/Services/ImageLoadState.swift
@@ -1,0 +1,144 @@
+//
+//  ImageLoadState.swift
+//  Microfiche
+//
+
+import AppKit
+import Foundation
+
+enum ImageLoadPhase: Equatable {
+    case idle
+    case placeholder
+    case downloading
+    case loading
+    case loaded
+    case failed(String)
+    case cancelled
+}
+
+struct ImageLoadState: Equatable {
+    private(set) var phase: ImageLoadPhase = .idle
+    private(set) var requestID: UUID?
+
+    mutating func observe(_ itemState: ICloudItemState) {
+        requestID = nil
+        switch itemState {
+        case .notDownloaded:
+            phase = .placeholder
+        case .failed(let message):
+            phase = .failed(message)
+        case .downloading:
+            phase = .downloading
+        case .local, .current:
+            phase = .idle
+        }
+    }
+
+    mutating func begin(for itemState: ICloudItemState) -> UUID {
+        let id = UUID()
+        requestID = id
+        phase = itemState.needsDownload ? .downloading : .loading
+        return id
+    }
+
+    @discardableResult
+    mutating func finish(
+        _ result: Result<Void, Error>,
+        requestID: UUID
+    ) -> Bool {
+        guard self.requestID == requestID else { return false }
+        self.requestID = nil
+        switch result {
+        case .success:
+            phase = .loaded
+        case .failure(let error as CancellationError):
+            _ = error
+            phase = .cancelled
+        case .failure(let error):
+            phase = .failed(error.localizedDescription)
+        }
+        return true
+    }
+
+    @discardableResult
+    mutating func cancel(requestID: UUID) -> Bool {
+        guard self.requestID == requestID else { return false }
+        self.requestID = nil
+        phase = .cancelled
+        return true
+    }
+}
+
+enum PreviewImageLoadError: Error, LocalizedError {
+    case unreadable(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .unreadable(let fileName):
+            return "Microfiche couldn’t load \(fileName)."
+        }
+    }
+}
+
+@MainActor
+final class PreviewImageLoadModel: ObservableObject {
+    @Published private(set) var image: NSImage?
+    @Published private(set) var state = ImageLoadState()
+
+    private var task: Task<Void, Never>?
+    private var url: URL?
+
+    func prepare(url: URL) {
+        guard self.url != url || state.phase == .idle else { return }
+        task?.cancel()
+        self.url = url
+        image = nil
+
+        let itemState = url.iCloudItemState
+        var nextState = state
+        nextState.observe(itemState)
+        state = nextState
+
+        switch itemState {
+        case .notDownloaded, .failed:
+            return
+        case .local, .current, .downloading:
+            load()
+        }
+    }
+
+    func load() {
+        guard let url else { return }
+        task?.cancel()
+
+        var nextState = state
+        let requestID = nextState.begin(for: url.iCloudItemState)
+        state = nextState
+
+        task = Task { [weak self] in
+            guard let self else { return }
+            do {
+                let loaded = try await PreviewImageCache.shared.image(for: url)
+                try Task.checkCancellation()
+                guard self.url == url else { return }
+                image = loaded
+                var completedState = state
+                _ = completedState.finish(.success(()), requestID: requestID)
+                state = completedState
+            } catch {
+                guard self.url == url else { return }
+                var completedState = state
+                _ = completedState.finish(.failure(error), requestID: requestID)
+                state = completedState
+            }
+        }
+    }
+
+    func cancel() {
+        task?.cancel()
+        guard let requestID = state.requestID else { return }
+        var nextState = state
+        _ = nextState.cancel(requestID: requestID)
+        state = nextState
+    }
+}

--- a/Microfiche/Services/PreviewImageCache.swift
+++ b/Microfiche/Services/PreviewImageCache.swift
@@ -36,6 +36,32 @@ final class PreviewImageCache {
         cache.object(forKey: url as NSURL)
     }
 
+    func image(
+        for url: URL,
+        priority: DispatchQoS.QoSClass = .userInitiated
+    ) async throws -> NSImage {
+        if let cached = getImage(for: url) {
+            return cached
+        }
+
+        try await ICloudItemDownloadCoordinator.shared.prepareForReading(url)
+        try Task.checkCancellation()
+
+        let image: NSImage = try await withCheckedThrowingContinuation { continuation in
+            enqueueImageLoad(for: url, priority: priority) { image in
+                if let image {
+                    continuation.resume(returning: image)
+                } else {
+                    continuation.resume(
+                        throwing: PreviewImageLoadError.unreadable(url.lastPathComponent)
+                    )
+                }
+            }
+        }
+        try Task.checkCancellation()
+        return image
+    }
+
     func preloadImage(
         for url: URL,
         priority: DispatchQoS.QoSClass = .userInitiated,

--- a/Microfiche/Services/UITestFixture.swift
+++ b/Microfiche/Services/UITestFixture.swift
@@ -43,9 +43,15 @@ struct UITestFixture {
             fileManager.fileExists(atPath: $0.path)
         })
 
-        let defaultsName = "MicroficheUITests.\(UUID().uuidString)"
+        let arguments = ProcessInfo.processInfo.arguments
+        let defaultsName: String
+        if let markerIndex = arguments.firstIndex(of: "--ui-testing-defaults-suite"),
+           arguments.indices.contains(markerIndex + 1) {
+            defaultsName = arguments[markerIndex + 1]
+        } else {
+            defaultsName = "MicroficheUITests.\(UUID().uuidString)"
+        }
         let defaults = UserDefaults(suiteName: defaultsName)!
-        defaults.removePersistentDomain(forName: defaultsName)
         defaults.set(false, forKey: "isOnboardingEnabled")
         defaults.set(true, forKey: "hasCompletedOnboarding")
 

--- a/Microfiche/Services/UITestFixture.swift
+++ b/Microfiche/Services/UITestFixture.swift
@@ -1,0 +1,79 @@
+//
+//  UITestFixture.swift
+//  Microfiche
+//
+
+#if DEBUG
+import Foundation
+
+@MainActor
+struct UITestFixture {
+    let libraryStorage: LibraryStorage
+    let contactSheetStorage: ContactSheetStorage
+    let userPreferences: UserPreferences
+    let archiveFolderStore: ArchiveFolderStore
+    let libraryIndex: LibraryIndexStore
+
+    static func make() -> UITestFixture {
+        let fileManager = FileManager.default
+        let root = fileManager.temporaryDirectory
+            .appendingPathComponent("microfiche-ui-fixture-\(UUID().uuidString)", isDirectory: true)
+        let photos = root.appendingPathComponent("Photos", isDirectory: true)
+        try? fileManager.createDirectory(at: photos, withIntermediateDirectories: true)
+
+        let pngData = Data(base64Encoded:
+            "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="
+        )!
+        let imageURLs = (1...24).map { index in
+            let url = photos.appendingPathComponent(
+                String(format: "fixture-%02d.png", index)
+            )
+            try? pngData.write(to: url)
+            return url
+        }
+
+        let defaultsName = "MicroficheUITests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: defaultsName)!
+        defaults.removePersistentDomain(forName: defaultsName)
+        defaults.set(false, forKey: "isOnboardingEnabled")
+        defaults.set(true, forKey: "hasCompletedOnboarding")
+
+        let libraryStorage = LibraryStorage(
+            persistenceURL: root.appendingPathComponent("library.json"),
+            fileManager: fileManager,
+            observesWorkspace: false
+        )
+        _ = libraryStorage.addFolders([photos])
+
+        let contactSheetStorage = ContactSheetStorage(
+            baseDirectory: root.appendingPathComponent("ContactSheets"),
+            fileManager: fileManager
+        )
+        let firstSheet = contactSheetStorage.createContactSheet(name: "First Review")
+        let secondSheet = contactSheetStorage.createContactSheet(name: "Second Review")
+        _ = contactSheetStorage.addImages(
+            from: Array(imageURLs.prefix(4)),
+            to: firstSheet.id
+        )
+        _ = contactSheetStorage.addImages(
+            from: Array(imageURLs[4..<8]),
+            to: secondSheet.id
+        )
+
+        return UITestFixture(
+            libraryStorage: libraryStorage,
+            contactSheetStorage: contactSheetStorage,
+            userPreferences: UserPreferences(defaults: defaults),
+            archiveFolderStore: ArchiveFolderStore(
+                defaults: defaults,
+                fileManager: fileManager
+            ),
+            libraryIndex: LibraryIndexStore(
+                persistenceURL: root.appendingPathComponent("library-index.json"),
+                fileManager: fileManager,
+                watchesFileSystem: false
+            )
+        )
+    }
+}
+#endif

--- a/Microfiche/Services/UITestFixture.swift
+++ b/Microfiche/Services/UITestFixture.swift
@@ -19,7 +19,11 @@ struct UITestFixture {
         let root = fileManager.temporaryDirectory
             .appendingPathComponent("microfiche-ui-fixture-\(UUID().uuidString)", isDirectory: true)
         let photos = root.appendingPathComponent("Photos", isDirectory: true)
-        try? fileManager.createDirectory(at: photos, withIntermediateDirectories: true)
+        do {
+            try fileManager.createDirectory(at: photos, withIntermediateDirectories: true)
+        } catch {
+            preconditionFailure("Unable to create UI test fixture: \(error)")
+        }
 
         let pngData = Data(base64Encoded:
             "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="
@@ -28,9 +32,16 @@ struct UITestFixture {
             let url = photos.appendingPathComponent(
                 String(format: "fixture-%02d.png", index)
             )
-            try? pngData.write(to: url)
+            do {
+                try pngData.write(to: url)
+            } catch {
+                preconditionFailure("Unable to write UI test image: \(error)")
+            }
             return url
         }
+        precondition(imageURLs.allSatisfy {
+            fileManager.fileExists(atPath: $0.path)
+        })
 
         let defaultsName = "MicroficheUITests.\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: defaultsName)!
@@ -43,7 +54,11 @@ struct UITestFixture {
             fileManager: fileManager,
             observesWorkspace: false
         )
-        _ = libraryStorage.addFolders([photos])
+        let addedLocations = libraryStorage.addFolders([photos])
+        precondition(
+            addedLocations.folders.count == 1,
+            "UI test fixture folder could not be linked"
+        )
 
         let contactSheetStorage = ContactSheetStorage(
             baseDirectory: root.appendingPathComponent("ContactSheets"),
@@ -58,6 +73,12 @@ struct UITestFixture {
         _ = contactSheetStorage.addImages(
             from: Array(imageURLs[4..<8]),
             to: secondSheet.id
+        )
+        precondition(
+            contactSheetStorage.contactSheets.count == 2
+                && contactSheetStorage.getImages(for: firstSheet.id).count == 4
+                && contactSheetStorage.getImages(for: secondSheet.id).count == 4,
+            "UI test contact sheets were not seeded"
         )
 
         return UITestFixture(

--- a/Microfiche/Services/UserPreferences.swift
+++ b/Microfiche/Services/UserPreferences.swift
@@ -19,6 +19,8 @@ final class UserPreferences: ObservableObject {
 
     private let defaults: UserDefaults
 
+    var defaultsStore: UserDefaults { defaults }
+
     /// Master switch for the welcome sequence. Off hides onboarding (useful while testing).
     @Published var isOnboardingEnabled: Bool {
         didSet {

--- a/Microfiche/Views/ImageDetailView.swift
+++ b/Microfiche/Views/ImageDetailView.swift
@@ -231,6 +231,7 @@ struct ImageMetadataInspectorView: View {
             }
         }
         .microficheInspectorContentChrome()
+        .accessibilityIdentifier("inspector.content")
     }
 
     private var selectedLabel: FinderLabel? {
@@ -251,6 +252,7 @@ struct ImageMetadataInspectorView: View {
                     .font(.system(size: 15, weight: .semibold))
                     .lineLimit(2)
                     .textSelection(.enabled)
+                    .accessibilityIdentifier("inspector.current-file")
 
                 Text(file.url.deletingLastPathComponent().path)
                     .font(.caption)

--- a/Microfiche/Views/ImageDetailView.swift
+++ b/Microfiche/Views/ImageDetailView.swift
@@ -15,10 +15,6 @@ struct ImageDetailView: View {
     let file: ImageFile
     @Binding var isMetadataPresented: Bool
 
-    @State private var detailImage: NSImage?
-    @State private var isLoadingImage = true
-    @State private var imageRequestURL: URL?
-
     var body: some View {
         extendedImageCanvas
             .inspector(isPresented: $isMetadataPresented) {
@@ -60,9 +56,6 @@ struct ImageDetailView: View {
                     .help("More")
                 }
             }
-            .task(id: file.id) {
-                loadDetailImage()
-            }
     }
 
     @ViewBuilder
@@ -85,43 +78,16 @@ struct ImageDetailView: View {
                 } else if file.url.pathExtension.lowercased() == "svg" {
                     SVGImageView(url: file.url)
                         .aspectRatio(contentMode: .fit)
-                } else if let image = detailImage {
-                    Image(nsImage: image)
-                        .resizable()
-                        .interpolation(.high)
-                        .aspectRatio(contentMode: .fit)
-                } else if isLoadingImage {
-                    ProgressView()
+                } else {
+                    RecoverablePreviewImage(url: file.url)
                 }
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .padding(28)
         }
+        .accessibilityIdentifier("image.detail")
     }
 
-    private func loadDetailImage() {
-        detailImage = nil
-        isLoadingImage = true
-        imageRequestURL = file.url
-
-        guard !["pdf", "svg"].contains(file.url.pathExtension.lowercased()) else {
-            isLoadingImage = false
-            return
-        }
-
-        if let cached = PreviewImageCache.shared.getImage(for: file.url) {
-            detailImage = cached
-            isLoadingImage = false
-            return
-        }
-
-        let requestedURL = file.url
-        PreviewImageCache.shared.preloadImage(for: requestedURL) { image in
-            guard imageRequestURL == requestedURL else { return }
-            detailImage = image
-            isLoadingImage = false
-        }
-    }
 }
 
 // MARK: - Metadata Inspector

--- a/Microfiche/Views/MainContentView.swift
+++ b/Microfiche/Views/MainContentView.swift
@@ -302,9 +302,13 @@ private struct EmptyLibraryStateView: View {
                 Button("Try Again", action: onRetryUnavailableLocation)
                     .buttonStyle(.borderedProminent)
                     .keyboardShortcut(.defaultAction)
+                    .accessibilityIdentifier("library-location.retry")
             }
         }
         .padding(.horizontal, 24)
+        .accessibilityIdentifier(
+            unavailableLocation == nil ? "library.empty" : "library-location.unavailable"
+        )
     }
 
     private var emptyStateMessage: String {
@@ -544,6 +548,11 @@ struct GridCell: View {
             onAddToContactSheet: onAddToContactSheet,
             onArchive: onArchive
         )
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(file.name)
+        .accessibilityValue(isSelected ? "Selected" : "Not selected")
+        .accessibilityAddTraits(isSelected ? [.isSelected] : [])
+        .accessibilityIdentifier("image.\(file.name)")
     }
 }
 
@@ -664,6 +673,11 @@ struct ImageListRow: View {
                 onDoubleClick: { onDoubleClickImage(file.id) }
             )
         }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(file.name)
+        .accessibilityValue(isSelected ? "Selected" : "Not selected")
+        .accessibilityAddTraits(isSelected ? [.isSelected] : [])
+        .accessibilityIdentifier("image.\(file.name)")
     }
 }
 

--- a/Microfiche/Views/PreviewView.swift
+++ b/Microfiche/Views/PreviewView.swift
@@ -10,8 +10,6 @@ import SwiftUI
 struct PreviewView: View {
     let file: ImageFile
     let onDismiss: () -> Void
-    @State private var previewImage: NSImage?
-    @State private var isLoading = true
 
     var body: some View {
         GeometryReader { geometry in
@@ -29,12 +27,8 @@ struct PreviewView: View {
                             SVGImageView(url: file.url)
                                 .frame(maxWidth: .infinity, maxHeight: .infinity)
                                 .aspectRatio(contentMode: .fit)
-                        } else if let image = previewImage {
-                            Image(nsImage: image)
-                                .resizable()
-                                .aspectRatio(contentMode: .fit)
-                        } else if isLoading {
-                            ProgressView()
+                        } else {
+                            RecoverablePreviewImage(url: file.url)
                         }
                     }
                     .padding(32)
@@ -42,35 +36,5 @@ struct PreviewView: View {
                 .frame(width: geometry.size.width * 0.75, height: geometry.size.height * 0.75)
             }
         }
-        .task(id: file.id) {
-            await loadPreviewImage()
-        }
-    }
-
-    @MainActor
-    private func loadPreviewImage() async {
-        previewImage = nil
-        isLoading = true
-
-        guard !["pdf", "svg"].contains(file.url.pathExtension.lowercased()) else {
-            isLoading = false
-            return
-        }
-
-        if let cached = PreviewImageCache.shared.getImage(for: file.url) {
-            previewImage = cached
-            isLoading = false
-            return
-        }
-
-        let loadedImage: NSImage? = await withCheckedContinuation { continuation in
-            PreviewImageCache.shared.preloadImage(for: file.url) { image in
-                continuation.resume(returning: image)
-            }
-        }
-
-        guard !Task.isCancelled else { return }
-        previewImage = loadedImage
-        isLoading = false
     }
 }

--- a/Microfiche/Views/RecoverablePreviewImage.swift
+++ b/Microfiche/Views/RecoverablePreviewImage.swift
@@ -47,6 +47,9 @@ struct RecoverablePreviewImage: View {
         case .downloading:
             ProgressView("Downloading from iCloud…")
                 .accessibilityIdentifier("image-load.downloading")
+        case .retrying:
+            ProgressView("Retrying…")
+                .accessibilityIdentifier("image-load.retrying")
         case .failed(let message):
             recoveryMessage(
                 title: "Image unavailable",

--- a/Microfiche/Views/RecoverablePreviewImage.swift
+++ b/Microfiche/Views/RecoverablePreviewImage.swift
@@ -1,0 +1,94 @@
+//
+//  RecoverablePreviewImage.swift
+//  Microfiche
+//
+
+import SwiftUI
+
+struct RecoverablePreviewImage: View {
+    let url: URL
+    var loadingLabel = "Loading image…"
+
+    @StateObject private var model = PreviewImageLoadModel()
+
+    var body: some View {
+        Group {
+            if let image = model.image {
+                Image(nsImage: image)
+                    .resizable()
+                    .interpolation(.high)
+                    .aspectRatio(contentMode: .fit)
+                    .accessibilityIdentifier("image-load.loaded")
+            } else {
+                statusContent
+            }
+        }
+        .task(id: url) {
+            model.prepare(url: url)
+        }
+        .onDisappear {
+            model.cancel()
+        }
+    }
+
+    @ViewBuilder
+    private var statusContent: some View {
+        switch model.state.phase {
+        case .idle, .loading:
+            ProgressView(loadingLabel)
+                .accessibilityIdentifier("image-load.loading")
+        case .placeholder:
+            recoveryMessage(
+                title: "Stored in iCloud",
+                message: "Download this image to view it in Microfiche.",
+                buttonTitle: "Download",
+                identifier: "image-load.download"
+            )
+        case .downloading:
+            ProgressView("Downloading from iCloud…")
+                .accessibilityIdentifier("image-load.downloading")
+        case .failed(let message):
+            recoveryMessage(
+                title: "Image unavailable",
+                message: message,
+                buttonTitle: "Try Again",
+                identifier: "image-load.retry"
+            )
+        case .cancelled:
+            recoveryMessage(
+                title: "Loading cancelled",
+                message: "The image was not changed.",
+                buttonTitle: "Try Again",
+                identifier: "image-load.retry"
+            )
+        case .loaded:
+            EmptyView()
+        }
+    }
+
+    private func recoveryMessage(
+        title: String,
+        message: String,
+        buttonTitle: String,
+        identifier: String
+    ) -> some View {
+        VStack(spacing: 10) {
+            Image(systemName: "icloud.and.arrow.down")
+                .font(.system(size: 28))
+                .foregroundStyle(.secondary)
+            Text(title)
+                .font(.headline)
+            Text(message)
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+            Button(buttonTitle) {
+                model.load()
+            }
+            .buttonStyle(.borderedProminent)
+            .accessibilityIdentifier(identifier)
+        }
+        .frame(maxWidth: 320)
+        .padding()
+    }
+}

--- a/Microfiche/Views/SidebarView.swift
+++ b/Microfiche/Views/SidebarView.swift
@@ -290,6 +290,12 @@ private struct SidebarStaticRow: View {
         .contentShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
         .onHover { isHovered = $0 }
         .onTapGesture(perform: action)
+        .accessibilityElement(children: .combine)
+        .accessibilityValue(isSelected ? "Selected" : "")
+        .accessibilityAddTraits(isSelected ? [.isSelected] : [])
+        .accessibilityIdentifier(
+            title == "All Images" ? "sidebar.all-images" : "sidebar.folder.\(title)"
+        )
     }
 }
 
@@ -487,6 +493,9 @@ struct ContactSheetSidebarItem: View {
             isTargeted: $isDropTargeted,
             perform: handleDrop
         )
+        .accessibilityElement(children: .combine)
+        .accessibilityValue(isSelected ? "Selected" : "")
+        .accessibilityAddTraits(isSelected ? [.isSelected] : [])
         .accessibilityIdentifier("contact-sheet-\(contactSheet.id.uuidString)-drop-target")
         .contextMenu {
             Button("Export PDF…") {

--- a/MicroficheTests/MicroficheTests.swift
+++ b/MicroficheTests/MicroficheTests.swift
@@ -515,6 +515,84 @@ final class MicroficheTests: XCTestCase {
         XCTAssertEqual(Set(secondApply.map(\.path)), [created.path])
     }
 
+    @MainActor
+    func testLinkedFolderDisconnectAndReconnectPreservesIdentityWithoutDuplicates() async throws {
+        let fileManager = FileManager.default
+        let root = fileManager.temporaryDirectory
+            .appendingPathComponent("microfiche-reconnect-\(UUID().uuidString)")
+        let photos = root.appendingPathComponent("Photos", isDirectory: true)
+        let libraryURL = root.appendingPathComponent("library.json")
+        let indexURL = root.appendingPathComponent("library-index.json")
+        try fileManager.createDirectory(at: photos, withIntermediateDirectories: true)
+        try Data("first".utf8).write(to: photos.appendingPathComponent("first.jpg"))
+        defer { try? fileManager.removeItem(at: root) }
+
+        let storage = LibraryStorage(
+            persistenceURL: libraryURL,
+            fileManager: fileManager,
+            observesWorkspace: false
+        )
+        let added = try XCTUnwrap(storage.addFolders([photos]).folders.first)
+        let index = LibraryIndexStore(
+            persistenceURL: indexURL,
+            fileManager: fileManager,
+            watchesFileSystem: false
+        )
+        index.configure(folders: storage.linkedFolders)
+        await index.reconcile(folderID: added.id)
+        XCTAssertEqual(index.files(for: [added.id]).map(\.name), ["first.jpg"])
+
+        try fileManager.removeItem(at: photos)
+        storage.refreshLocations()
+        XCTAssertEqual(storage.linkedFolders.map(\.id), [added.id])
+        XCTAssertFalse(try XCTUnwrap(storage.folder(id: added.id)).isAvailable)
+        index.configure(folders: storage.linkedFolders)
+        await index.reconcileAll()
+        XCTAssertEqual(index.files(for: [added.id]).map(\.name), ["first.jpg"])
+
+        try fileManager.createDirectory(at: photos, withIntermediateDirectories: true)
+        try Data("restored".utf8).write(to: photos.appendingPathComponent("restored.jpg"))
+        storage.refreshLocations()
+        XCTAssertEqual(storage.linkedFolders.map(\.id), [added.id])
+        XCTAssertTrue(try XCTUnwrap(storage.folder(id: added.id)).isAvailable)
+        index.configure(folders: storage.linkedFolders)
+        await index.reconcileAll()
+        XCTAssertEqual(index.files(for: [added.id]).map(\.name), ["restored.jpg"])
+    }
+
+    func testBrowsingStateClearsStaleSelectionOnDisconnectAndStaysClearAfterReconnect() {
+        let first = ImageFile(url: URL(fileURLWithPath: "/Volumes/Photos/first.jpg"))
+        let initial = LibraryBrowsingState(
+            selectedIDs: [first.id],
+            focusedID: first.id,
+            detailID: first.id,
+            isQuickPreviewPresented: true
+        )
+
+        let disconnected = LibraryBrowsingRecovery.reconciling(initial, with: [])
+        XCTAssertEqual(
+            disconnected,
+            LibraryBrowsingState(
+                selectedIDs: [],
+                focusedID: nil,
+                detailID: nil,
+                isQuickPreviewPresented: false
+            )
+        )
+
+        let restored = ImageFile(
+            url: URL(fileURLWithPath: "/Volumes/Photos/restored.jpg")
+        )
+        let reconnected = LibraryBrowsingRecovery.reconciling(
+            disconnected,
+            with: [first, restored]
+        )
+        XCTAssertTrue(reconnected.selectedIDs.isEmpty)
+        XCTAssertNil(reconnected.focusedID)
+        XCTAssertNil(reconnected.detailID)
+        XCTAssertFalse(reconnected.isQuickPreviewPresented)
+    }
+
     private func makeLinkedFolder(
         id: UUID = UUID(),
         url: URL,
@@ -651,7 +729,7 @@ final class MicroficheTests: XCTestCase {
         XCTAssertEqual(state.phase, .failed("Network unavailable"))
 
         let retry = state.begin(for: .downloading)
-        XCTAssertEqual(state.phase, .downloading)
+        XCTAssertEqual(state.phase, .retrying)
         XCTAssertTrue(state.cancel(requestID: retry))
         XCTAssertEqual(state.phase, .cancelled)
         XCTAssertFalse(state.cancel(requestID: retry))
@@ -676,6 +754,18 @@ final class MicroficheTests: XCTestCase {
         try await success.prepareForReading(url)
         try await success.prepareForReading(url)
         XCTAssertEqual(successDownloader.requestCount, 1)
+
+        let retryDownloader = StubICloudItemDownloader(states: [
+            .failed("Previous failure"), .failed("Previous failure"), .downloading, .current
+        ])
+        let retry = ICloudItemDownloadCoordinator(
+            downloader: retryDownloader,
+            maxPollAttempts: 4,
+            pollInterval: .zero,
+            sleep: { _ in }
+        )
+        try await retry.prepareForReading(url)
+        XCTAssertEqual(retryDownloader.requestCount, 1)
 
         let failed = ICloudItemDownloadCoordinator(
             downloader: StubICloudItemDownloader(states: [

--- a/MicroficheTests/MicroficheTests.swift
+++ b/MicroficheTests/MicroficheTests.swift
@@ -632,6 +632,96 @@ final class MicroficheTests: XCTestCase {
         XCTAssertEqual(folder.displayName, "Photos")
     }
 
+    func testImageLoadStateCoversPlaceholderLoadingFailureCancellationAndRetry() {
+        var state = ImageLoadState()
+        state.observe(.notDownloaded)
+        XCTAssertEqual(state.phase, .placeholder)
+
+        let download = state.begin(for: .notDownloaded)
+        XCTAssertEqual(state.phase, .downloading)
+        XCTAssertTrue(state.finish(.success(()), requestID: download))
+        XCTAssertEqual(state.phase, .loaded)
+
+        let failed = state.begin(for: .local)
+        XCTAssertEqual(state.phase, .loading)
+        XCTAssertTrue(state.finish(
+            .failure(ICloudItemDownloadError.unavailable("Network unavailable")),
+            requestID: failed
+        ))
+        XCTAssertEqual(state.phase, .failed("Network unavailable"))
+
+        let retry = state.begin(for: .downloading)
+        XCTAssertEqual(state.phase, .downloading)
+        XCTAssertTrue(state.cancel(requestID: retry))
+        XCTAssertEqual(state.phase, .cancelled)
+        XCTAssertFalse(state.cancel(requestID: retry))
+
+        let finalRetry = state.begin(for: .current)
+        XCTAssertFalse(state.finish(.success(()), requestID: failed))
+        XCTAssertTrue(state.finish(.success(()), requestID: finalRetry))
+        XCTAssertEqual(state.phase, .loaded)
+    }
+
+    func testICloudDownloadCoordinatorHandlesSuccessFailureTimeoutAndCancellation() async throws {
+        let url = URL(fileURLWithPath: "/tmp/microfiche-icloud-fixture.jpg")
+        let successDownloader = StubICloudItemDownloader(states: [
+            .notDownloaded, .downloading, .current
+        ])
+        let success = ICloudItemDownloadCoordinator(
+            downloader: successDownloader,
+            maxPollAttempts: 4,
+            pollInterval: .zero,
+            sleep: { _ in }
+        )
+        try await success.prepareForReading(url)
+        try await success.prepareForReading(url)
+        XCTAssertEqual(successDownloader.requestCount, 1)
+
+        let failed = ICloudItemDownloadCoordinator(
+            downloader: StubICloudItemDownloader(states: [
+                .notDownloaded, .failed("iCloud is unavailable")
+            ]),
+            maxPollAttempts: 2,
+            pollInterval: .zero,
+            sleep: { _ in }
+        )
+        do {
+            try await failed.prepareForReading(url)
+            XCTFail("Expected an iCloud failure")
+        } catch {
+            XCTAssertEqual(
+                error as? ICloudItemDownloadError,
+                .unavailable("iCloud is unavailable")
+            )
+        }
+
+        let timedOut = ICloudItemDownloadCoordinator(
+            downloader: StubICloudItemDownloader(states: [.notDownloaded]),
+            maxPollAttempts: 2,
+            pollInterval: .zero,
+            sleep: { _ in }
+        )
+        do {
+            try await timedOut.prepareForReading(url)
+            XCTFail("Expected an iCloud timeout")
+        } catch {
+            XCTAssertEqual(error as? ICloudItemDownloadError, .timedOut)
+        }
+
+        let cancelled = ICloudItemDownloadCoordinator(
+            downloader: StubICloudItemDownloader(states: [.notDownloaded]),
+            maxPollAttempts: 2,
+            pollInterval: .zero,
+            sleep: { _ in throw CancellationError() }
+        )
+        do {
+            try await cancelled.prepareForReading(url)
+            XCTFail("Expected cancellation")
+        } catch {
+            XCTAssertTrue(error is CancellationError)
+        }
+    }
+
     func testDroppedImagePersistsWhenContactSheetStorageReloads() throws {
         let fileManager = FileManager.default
         let testDirectory = fileManager.temporaryDirectory
@@ -1439,4 +1529,27 @@ final class MicroficheTests: XCTestCase {
         XCTAssertNil(restored.resolvedURL())
     }
 
+}
+
+private final class StubICloudItemDownloader: ICloudItemDownloading, @unchecked Sendable {
+    private let lock = NSLock()
+    private var states: [ICloudItemState]
+    private(set) var requestCount = 0
+
+    init(states: [ICloudItemState]) {
+        self.states = states
+    }
+
+    func state(for url: URL) -> ICloudItemState {
+        lock.withLock {
+            guard states.count > 1 else { return states.first ?? .local }
+            return states.removeFirst()
+        }
+    }
+
+    func requestDownload(for url: URL) throws {
+        lock.withLock {
+            requestCount += 1
+        }
+    }
 }

--- a/MicroficheUITests/MicroficheUITests.swift
+++ b/MicroficheUITests/MicroficheUITests.swift
@@ -70,18 +70,18 @@ final class MicroficheUITests: XCTestCase {
         XCTAssertTrue(inspectorButton.waitForExistence(timeout: 3))
         inspectorButton.click()
         XCTAssertTrue(
-            element("inspector.selection-summary", in: app)
+            element("inspector.content", in: app)
                 .waitForExistence(timeout: 2)
         )
         inspectorButton.click()
-        XCTAssertFalse(element("inspector.selection-summary", in: app).exists)
+        XCTAssertFalse(element("inspector.content", in: app).exists)
         inspectorButton.click()
         XCTAssertTrue(
-            element("inspector.selection-summary", in: app)
+            element("inspector.content", in: app)
                 .waitForExistence(timeout: 2)
         )
         inspectorButton.click()
-        XCTAssertFalse(element("inspector.selection-summary", in: app).exists)
+        XCTAssertFalse(element("inspector.content", in: app).exists)
     }
 
     @MainActor
@@ -110,6 +110,8 @@ final class MicroficheUITests: XCTestCase {
         XCTAssertTrue(second.isSelected)
         XCTAssertTrue(third.isSelected)
         fifth.click(forDuration: 0, modifierFlags: .shift)
+        XCTAssertTrue(third.isSelected)
+        XCTAssertTrue(fixtureImage(4, in: app).isSelected)
         XCTAssertTrue(fifth.isSelected)
 
         for _ in 0..<5 {
@@ -117,9 +119,9 @@ final class MicroficheUITests: XCTestCase {
         }
         XCTAssertTrue(first.isSelected)
 
-        first.typeKey(.rightArrow, modifierFlags: [])
+        app.typeKey(.rightArrow, modifierFlags: [])
         XCTAssertTrue(second.isSelected)
-        second.typeKey(.leftArrow, modifierFlags: [])
+        app.typeKey(.leftArrow, modifierFlags: [])
         XCTAssertTrue(first.isSelected)
         app.typeKey(.escape, modifierFlags: [])
         XCTAssertFalse(first.isSelected)
@@ -171,19 +173,23 @@ final class MicroficheUITests: XCTestCase {
         let app = configuredApp()
         app.launch()
 
-        for index in 1...2 {
-            let image = fixtureImage(index, in: app)
-            XCTAssertTrue(image.waitForExistence(timeout: 5))
-            image.click()
-            element("inspector.toggle", in: app).click()
-            XCTAssertTrue(
-                element("inspector.selection-summary", in: app)
-                    .waitForExistence(timeout: 2)
-            )
+        let first = fixtureImage(1, in: app)
+        XCTAssertTrue(first.waitForExistence(timeout: 5))
+        first.click()
+        element("inspector.toggle", in: app).click()
+        let inspectorFile = element("inspector.current-file", in: app)
+        XCTAssertTrue(inspectorFile.waitForExistence(timeout: 2))
+        XCTAssertEqual(inspectorFile.label, "fixture-01.png")
 
+        for index in 1...2 {
+            let removedImage = fixtureImage(index, in: app)
             app.typeKey(.delete, modifierFlags: [.command, .shift])
-            XCTAssertTrue(image.waitForNonExistence(timeout: 3))
-            XCTAssertFalse(element("inspector.selection-summary", in: app).exists)
+            XCTAssertTrue(removedImage.waitForNonExistence(timeout: 3))
+            XCTAssertTrue(inspectorFile.waitForExistence(timeout: 2))
+            XCTAssertEqual(
+                inspectorFile.label,
+                String(format: "fixture-%02d.png", index + 1)
+            )
         }
     }
 

--- a/MicroficheUITests/MicroficheUITests.swift
+++ b/MicroficheUITests/MicroficheUITests.swift
@@ -62,14 +62,146 @@ final class MicroficheUITests: XCTestCase {
         let app = configuredApp()
         app.launch()
 
+        let firstImage = element("image.fixture-01.png", in: app)
+        XCTAssertTrue(firstImage.waitForExistence(timeout: 5))
+        firstImage.click()
+
         let inspectorButton = element("inspector.toggle", in: app)
         XCTAssertTrue(inspectorButton.waitForExistence(timeout: 3))
         inspectorButton.click()
-        XCTAssertTrue(inspectorButton.waitForExistence(timeout: 2))
+        XCTAssertTrue(
+            element("inspector.selection-summary", in: app)
+                .waitForExistence(timeout: 2)
+        )
         inspectorButton.click()
-        XCTAssertTrue(inspectorButton.exists)
+        XCTAssertFalse(element("inspector.selection-summary", in: app).exists)
         inspectorButton.click()
-        XCTAssertTrue(inspectorButton.exists)
+        XCTAssertTrue(
+            element("inspector.selection-summary", in: app)
+                .waitForExistence(timeout: 2)
+        )
+        inspectorButton.click()
+        XCTAssertFalse(element("inspector.selection-summary", in: app).exists)
+    }
+
+    @MainActor
+    func testFixtureLibraryAndRepeatedSelectionTransitions() throws {
+        let app = configuredApp()
+        app.launch()
+
+        let first = fixtureImage(1, in: app)
+        let second = fixtureImage(2, in: app)
+        let third = fixtureImage(3, in: app)
+        let fifth = fixtureImage(5, in: app)
+        XCTAssertTrue(first.waitForExistence(timeout: 5))
+        XCTAssertTrue(fifth.exists)
+        XCTAssertTrue(app.staticTexts["First Review"].exists)
+        XCTAssertTrue(app.staticTexts["Second Review"].exists)
+        XCTAssertEqual(first.value as? String, "Not selected")
+
+        first.click()
+        XCTAssertTrue(first.isSelected)
+        second.click()
+        XCTAssertTrue(second.isSelected)
+        second.click()
+        XCTAssertTrue(second.isSelected)
+
+        third.click(forDuration: 0, modifierFlags: .command)
+        XCTAssertTrue(second.isSelected)
+        XCTAssertTrue(third.isSelected)
+        fifth.click(forDuration: 0, modifierFlags: .shift)
+        XCTAssertTrue(fifth.isSelected)
+
+        for _ in 0..<5 {
+            first.click()
+        }
+        XCTAssertTrue(first.isSelected)
+
+        first.typeKey(.rightArrow, modifierFlags: [])
+        XCTAssertTrue(second.isSelected)
+        second.typeKey(.leftArrow, modifierFlags: [])
+        XCTAssertTrue(first.isSelected)
+        app.typeKey(.escape, modifierFlags: [])
+        XCTAssertFalse(first.isSelected)
+
+        element("viewMode.list", in: app).click()
+        XCTAssertTrue(element("viewMode.list", in: app).isSelected)
+        third.click()
+        XCTAssertTrue(third.isSelected)
+        element("viewMode.grid", in: app).click()
+        XCTAssertTrue(element("viewMode.grid", in: app).isSelected)
+    }
+
+    @MainActor
+    func testDoubleClickDragAndContextMenuDoNotDisableLaterClicks() throws {
+        let app = configuredApp()
+        app.launch()
+
+        let first = fixtureImage(1, in: app)
+        let second = fixtureImage(2, in: app)
+        let third = fixtureImage(3, in: app)
+        XCTAssertTrue(first.waitForExistence(timeout: 5))
+
+        for image in [first, second] {
+            for _ in 0..<2 {
+                image.doubleClick()
+                XCTAssertTrue(
+                    element("image.detail", in: app).waitForExistence(timeout: 2)
+                )
+                app.typeKey(.escape, modifierFlags: [])
+                XCTAssertTrue(first.waitForExistence(timeout: 2))
+            }
+        }
+
+        let start = first.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5))
+        let end = first.coordinate(withNormalizedOffset: CGVector(dx: 0.8, dy: 0.5))
+        start.press(forDuration: 0.2, thenDragTo: end)
+        second.click()
+        XCTAssertTrue(second.isSelected)
+
+        second.rightClick()
+        XCTAssertTrue(app.menuItems["Move to Archive"].waitForExistence(timeout: 2))
+        app.typeKey(.escape, modifierFlags: [])
+        third.click()
+        XCTAssertTrue(third.isSelected)
+    }
+
+    @MainActor
+    func testRemovingSelectedImageClearsInspectorWithoutStaleContent() throws {
+        let app = configuredApp()
+        app.launch()
+
+        for index in 1...2 {
+            let image = fixtureImage(index, in: app)
+            XCTAssertTrue(image.waitForExistence(timeout: 5))
+            image.click()
+            element("inspector.toggle", in: app).click()
+            XCTAssertTrue(
+                element("inspector.selection-summary", in: app)
+                    .waitForExistence(timeout: 2)
+            )
+
+            app.typeKey(.delete, modifierFlags: [.command, .shift])
+            XCTAssertTrue(image.waitForNonExistence(timeout: 3))
+            XCTAssertFalse(element("inspector.selection-summary", in: app).exists)
+        }
+    }
+
+    @MainActor
+    func testSidebarAndInspectorTransitionBothDirectionsTwice() throws {
+        let app = configuredApp()
+        app.launch()
+
+        let sidebar = element("library.sidebar", in: app)
+        let toggle = element("sidebar.toggle", in: app)
+        XCTAssertTrue(sidebar.waitForExistence(timeout: 5))
+
+        for _ in 0..<2 {
+            toggle.click()
+            XCTAssertTrue(sidebar.waitForNonExistence(timeout: 2))
+            toggle.click()
+            XCTAssertTrue(sidebar.waitForExistence(timeout: 2))
+        }
     }
 
     @MainActor
@@ -88,9 +220,15 @@ final class MicroficheUITests: XCTestCase {
             "-ApplePersistenceIgnoreState", "YES",
             "-isOnboardingEnabled", "NO",
             "-hasCompletedOnboarding", "YES",
-            "--ui-testing"
+            "--ui-testing",
+            "--ui-testing-fixtures"
         ]
         return app
+    }
+
+    @MainActor
+    private func fixtureImage(_ index: Int, in app: XCUIApplication) -> XCUIElement {
+        element(String(format: "image.fixture-%02d.png", index), in: app)
     }
 
     private func element(_ identifier: String, in app: XCUIApplication) -> XCUIElement {

--- a/MicroficheUITests/MicroficheUITests.swift
+++ b/MicroficheUITests/MicroficheUITests.swift
@@ -194,7 +194,7 @@ final class MicroficheUITests: XCTestCase {
     }
 
     @MainActor
-    func testSidebarAndInspectorTransitionBothDirectionsTwice() throws {
+    func testSidebarCollapseAndExpansionPersistAcrossRelaunchTwice() throws {
         let app = configuredApp()
         app.launch()
 
@@ -205,8 +205,41 @@ final class MicroficheUITests: XCTestCase {
         for _ in 0..<2 {
             toggle.click()
             XCTAssertTrue(sidebar.waitForNonExistence(timeout: 2))
+            relaunch(app)
+            XCTAssertTrue(sidebar.waitForNonExistence(timeout: 2))
+
             toggle.click()
             XCTAssertTrue(sidebar.waitForExistence(timeout: 2))
+            relaunch(app)
+            XCTAssertTrue(sidebar.waitForExistence(timeout: 2))
+        }
+    }
+
+    @MainActor
+    func testInspectorCollapseAndExpansionPersistAcrossRelaunchTwice() throws {
+        let app = configuredApp()
+        app.launch()
+
+        let first = fixtureImage(1, in: app)
+        let inspector = element("inspector.content", in: app)
+        let toggle = element("inspector.toggle", in: app)
+        XCTAssertTrue(first.waitForExistence(timeout: 5))
+        first.click()
+
+        for _ in 0..<2 {
+            toggle.click()
+            XCTAssertTrue(inspector.waitForExistence(timeout: 2))
+            relaunch(app)
+            XCTAssertTrue(first.waitForExistence(timeout: 5))
+            first.click()
+            XCTAssertTrue(inspector.waitForExistence(timeout: 2))
+
+            toggle.click()
+            XCTAssertTrue(inspector.waitForNonExistence(timeout: 2))
+            relaunch(app)
+            XCTAssertTrue(first.waitForExistence(timeout: 5))
+            first.click()
+            XCTAssertTrue(inspector.waitForNonExistence(timeout: 2))
         }
     }
 
@@ -222,14 +255,24 @@ final class MicroficheUITests: XCTestCase {
     @MainActor
     private func configuredApp() -> XCUIApplication {
         let app = XCUIApplication()
+        let defaultsSuite = "MicroficheUITests.\(UUID().uuidString)"
         app.launchArguments = [
             "-ApplePersistenceIgnoreState", "YES",
             "-isOnboardingEnabled", "NO",
             "-hasCompletedOnboarding", "YES",
             "--ui-testing",
-            "--ui-testing-fixtures"
+            "--ui-testing-fixtures",
+            "--ui-testing-defaults-suite", defaultsSuite
         ]
         return app
+    }
+
+    @MainActor
+    private func relaunch(_ app: XCUIApplication) {
+        app.terminate()
+        XCTAssertTrue(app.wait(for: .notRunning, timeout: 5))
+        app.launch()
+        XCTAssertTrue(app.windows.firstMatch.waitForExistence(timeout: 5))
     }
 
     @MainActor

--- a/MicroficheUITests/MicroficheUITestsLaunchTests.swift
+++ b/MicroficheUITests/MicroficheUITestsLaunchTests.swift
@@ -20,11 +20,20 @@ final class MicroficheUITestsLaunchTests: XCTestCase {
     @MainActor
     func testLaunch() throws {
         let app = XCUIApplication()
-        app.launchArguments.append("--ui-testing")
+        app.launchArguments = [
+            "-ApplePersistenceIgnoreState", "YES",
+            "--ui-testing",
+            "--ui-testing-fixtures",
+            "--ui-testing-defaults-suite",
+            "MicroficheUITests.Launch.\(UUID().uuidString)"
+        ]
         app.launch()
-
-        // Insert steps here to perform after app launch but before taking a screenshot,
-        // such as logging into a test account or navigating somewhere in the app
+        XCTAssertTrue(
+            app.descendants(matching: .any)
+                .matching(identifier: "image.fixture-01.png")
+                .firstMatch
+                .waitForExistence(timeout: 5)
+        )
 
         let attachment = XCTAttachment(screenshot: app.screenshot())
         attachment.name = "Launch Screen"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- model iCloud placeholder, download, retrying, loading, failure, cancellation, and success states
- show actionable download and retry states in quick preview and image detail
- preserve linked folders across disconnects, reconcile reconnects without duplicates, and clear stale browsing/inspector state
- add an isolated 24-image/two-contact-sheet UI fixture with private preferences and storage
- cover repeated selection, modifiers, keyboard navigation, double-click, drag, context menus, selected-file removal, and iCloud/volume recovery transitions
- verify sidebar and inspector collapsed/expanded preferences in both directions across repeated app relaunches

## Verification
- Static review completed with no definite Swift compile errors found.
- `xcodebuild` and `swiftc` are unavailable in this Linux cloud environment, so the signed macOS test suite and Debug build remain pending on a macOS/Xcode runner.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a0509a-c01a-73e8-9045-338635feeb9e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a0509a-c01a-73e8-9045-338635feeb9e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

