### PR TITLE
PCD-31: Complete keyboard and accessibility audit

### DIFF
--- a/ACCESSIBILITY_AUDIT.md
+++ b/ACCESSIBILITY_AUDIT.md
@@ -1,0 +1,39 @@
+# Microfiche Accessibility Audit
+
+This checklist covers the library, detail, quick preview, inspector, and contact-sheet workflows required by PCD-31. Run the manual sections on a Mac after the automated suite because VoiceOver speech, system focus rings, Liquid Glass, and appearance settings cannot be validated from snapshots or a Linux build host.
+
+## Automated coverage
+
+| Area | Covered states |
+| --- | --- |
+| Keyboard selection | No selection, first and different selection, repeated selection, Command-click, Shift-click, arrows, Escape, grid/list transitions |
+| Pointer interaction | Selected/unselected double-click twice, drag initiation, context menu, subsequent click |
+| Panels and navigation | Sidebar and inspector collapse/expand in both directions, persistence across two relaunches, selected item removal |
+| Accessibility semantics | Image names and selected values; detail image, inspector, share, and more-action labels; sidebar, contact-sheet, editor, and status semantics |
+| Announcements | Empty/single/multiple selection, focused item, image loading/failure/cancellation, and contact-sheet drop outcomes |
+| Reduce Motion | All shared snap, transition, and panel tokens resolve to no animation; repeated preview and view-mode transitions run with Reduce Motion enabled |
+| Increased contrast | Selection fill/stroke metrics strengthen; repeated selection and view transitions run with a deterministic Increased Contrast override |
+
+## Manual VoiceOver audit
+
+Run each workflow twice without relaunching.
+
+- [ ] With VoiceOver on, traverse the toolbar, sidebar, grid, list, inspector, menus, and editors. Confirm each control announces an accurate name, role, value, enabled state, and selected state.
+- [ ] Select one image, a different image, and multiple images. Confirm one concise selection announcement per change and that the focused filename is announced for multi-selection.
+- [ ] Open and close Quick Preview and detail twice. Confirm focus remains predictable and the modal preview exposes its Close Preview action.
+- [ ] Exercise local, iCloud placeholder, downloading, loaded, failed, cancelled, and retry states. Confirm state changes are announced once and retry controls remain reachable.
+- [ ] Drop one image, multiple images, and duplicate images on a Contact Sheet. Confirm the result announcement reports newly added images without duplicate chatter.
+- [ ] Use keyboard focus traversal and the documented shortcuts with the sidebar and inspector both collapsed and expanded. Confirm the visible accent focus/selection ring follows the focused image.
+
+## Manual appearance audit
+
+Test at minimum, ideal, and expanded window widths.
+
+- [ ] Light appearance
+- [ ] Dark appearance
+- [ ] Increase Contrast
+- [ ] Reduce Transparency
+- [ ] Reduce Motion
+- [ ] Liquid Glass on macOS 26
+
+Confirm text and icons remain legible, selection does not rely on fill alone, increased contrast adds a stronger outline, floating controls retain a visible boundary, and Reduce Motion removes preview, onboarding, hover, resize, scroll, sidebar, and inspector animation without hiding state changes.

--- a/ACCESSIBILITY_AUDIT.md
+++ b/ACCESSIBILITY_AUDIT.md
@@ -13,6 +13,7 @@ This checklist covers the library, detail, quick preview, inspector, and contact
 | Announcements | Empty/single/multiple selection, focused item, image loading/failure/cancellation, and contact-sheet drop outcomes |
 | Reduce Motion | All shared snap, transition, and panel tokens resolve to no animation; repeated preview and view-mode transitions run with Reduce Motion enabled |
 | Increased contrast | Selection fill/stroke metrics strengthen; repeated selection and view transitions run with a deterministic Increased Contrast override |
+| Reduce Transparency | Glass panels, floating controls, inspector reading surfaces, and detail extension effects use deterministic solid-surface fallbacks |
 
 ## Manual VoiceOver audit
 

--- a/Microfiche/ContentView.swift
+++ b/Microfiche/ContentView.swift
@@ -124,6 +124,11 @@ private struct ContactSheetExportPresentation: Identifiable {
     var id: UUID { contactSheet.id }
 }
 
+private struct AccessibilitySelectionSnapshot: Equatable {
+    let selectedIDs: Set<UUID>
+    let focusedID: UUID?
+}
+
 // MARK: - Content View
 
 struct ContentView: View {
@@ -270,6 +275,14 @@ struct ContentView: View {
                 .onChange(of: selectedTag) {
                     pruneSelectionToVisibleFiles()
                 }
+                .onChange(of: accessibilitySelectionSnapshot) {
+                    MicroficheAccessibility.announce(
+                        MicroficheAccessibility.selectionAnnouncement(
+                            selectedFiles: selectedImageFiles,
+                            focusedFile: focusedImageFile
+                        )
+                    )
+                }
                 .onChange(of: libraryStorage.linkedFolders) {
                     libraryIndex.configure(folders: libraryStorage.linkedFolders)
                     reloadSelectedLibraryLocation()
@@ -415,8 +428,14 @@ struct ContentView: View {
                     .zIndex(10)
                 }
         }
-        .animation(MicroficheMotion.snap, value: isQuickPreviewPresented)
-        .animation(MicroficheMotion.transition, value: userPreferences.isPresentingOnboarding)
+        .animation(
+            MicroficheMotion.snap(reducedMotion: reduceMotion),
+            value: isQuickPreviewPresented
+        )
+        .animation(
+            MicroficheMotion.transition(reducedMotion: reduceMotion),
+            value: userPreferences.isPresentingOnboarding
+        )
         .task {
             libraryIndex.configure(folders: libraryStorage.linkedFolders)
             if !ProcessInfo.processInfo.arguments.contains("--ui-testing") {
@@ -498,6 +517,7 @@ struct ContentView: View {
                 isResizingGrid: isResizingGrid,
                 gridColumnCount: $gridColumnCount,
                 selectedImageFileIDs: $selectedImageFileIDs,
+                focusedImageFileID: focusedImageFileID,
                 onSelectImage: handleImageSelection,
                 onDoubleClickImage: handleDoubleClickImage,
                 scrollToID: $scrollToID,
@@ -611,6 +631,13 @@ struct ContentView: View {
             return visible
         }
         return imageFiles.filter { selectedImageFileIDs.contains($0.id) }
+    }
+
+    private var accessibilitySelectionSnapshot: AccessibilitySelectionSnapshot {
+        AccessibilitySelectionSnapshot(
+            selectedIDs: selectedImageFileIDs,
+            focusedID: focusedImageFileID
+        )
     }
 
     private var focusedImageFile: ImageFile? {
@@ -875,7 +902,20 @@ struct ContentView: View {
         let supportedURLs = urls.filter {
             SupportedImageExtensions.contains($0)
         }
+        guard let sheet = contactSheetStorage.contactSheets.first(where: {
+            $0.id == sheetID
+        }) else { return }
+        let previousCount = sheet.imageIDs.count
         _ = contactSheetStorage.addImages(from: supportedURLs, to: sheetID)
+        let nextCount = contactSheetStorage.contactSheets.first(where: {
+            $0.id == sheetID
+        })?.imageIDs.count ?? previousCount
+        MicroficheAccessibility.announce(
+            MicroficheAccessibility.dropAnnouncement(
+                addedCount: max(0, nextCount - previousCount),
+                contactSheetName: sheet.name
+            )
+        )
 
         if selection == .contactSheet(sheetID) {
             imageFiles = contactSheetStorage.getImages(for: sheetID)

--- a/Microfiche/ContentView.swift
+++ b/Microfiche/ContentView.swift
@@ -565,6 +565,7 @@ struct ContentView: View {
                         Image(systemName: "photo")
                             .font(.system(size: 11))
                             .foregroundStyle(.secondary)
+                            .accessibilityHidden(true)
 
                         Slider(
                             value: gridThumbnailSizeBinding,
@@ -578,6 +579,7 @@ struct ContentView: View {
                         Image(systemName: "photo.fill")
                             .font(.system(size: 15))
                             .foregroundStyle(.secondary)
+                            .accessibilityHidden(true)
                     }
                     .fixedSize()
                     .help("Thumbnail Size")
@@ -600,6 +602,11 @@ struct ContentView: View {
                 .disabled(selectedImageFileIDs.isEmpty)
                 .help(isMetadataInspectorPresented ? "Hide Info" : "Show Info")
                 .accessibilityLabel(isMetadataInspectorPresented ? "Hide inspector" : "Show inspector")
+                .accessibilityHint(
+                    selectedImageFileIDs.isEmpty
+                        ? "Select an image to inspect its metadata"
+                        : "Shows metadata for the selected images"
+                )
                 .accessibilityIdentifier("inspector.toggle")
             }
             .hideSharedBackgroundIfAvailable()
@@ -675,6 +682,21 @@ struct ContentView: View {
         ImageMetadataStore.shared.allTags(for: imageFiles.map(\.url))
     }
 
+    private var filterAccessibilityValue: String {
+        var parts: [String] = []
+        let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !query.isEmpty {
+            parts.append("Search \(query)")
+        }
+        if !selectedFileType.isEmpty {
+            parts.append("File type \(selectedFileType.uppercased())")
+        }
+        if !selectedTag.isEmpty {
+            parts.append("Tag \(selectedTag)")
+        }
+        return parts.isEmpty ? "No filters" : parts.joined(separator: ", ")
+    }
+
     private var filterMenu: some View {
         Menu {
             Picker("File Type", selection: $selectedFileType) {
@@ -703,7 +725,7 @@ struct ContentView: View {
         }
         .help("Filter Library")
         .accessibilityLabel("Filter library")
-        .accessibilityValue(hasActiveFilter ? "Filters active" : "No filters")
+        .accessibilityValue(filterAccessibilityValue)
         .accessibilityIdentifier("library.filter")
     }
 

--- a/Microfiche/MicroficheApp.swift
+++ b/Microfiche/MicroficheApp.swift
@@ -37,6 +37,13 @@ struct MicroficheApp: App {
                     }
                     #endif
                 }
+                .transformEnvironment(\.accessibilityReduceTransparency) { reduceTransparency in
+                    #if DEBUG
+                    if ProcessInfo.processInfo.arguments.contains("--ui-testing-reduce-transparency") {
+                        reduceTransparency = true
+                    }
+                    #endif
+                }
         }
         .defaultSize(width: WindowLayout.defaultWidth, height: WindowLayout.defaultHeight)
         .defaultPosition(.center)

--- a/Microfiche/MicroficheApp.swift
+++ b/Microfiche/MicroficheApp.swift
@@ -23,6 +23,20 @@ struct MicroficheApp: App {
                     minWidth: WindowLayout.minimumWidth,
                     minHeight: WindowLayout.minimumHeight
                 )
+                .transformEnvironment(\.accessibilityReduceMotion) { reduceMotion in
+                    #if DEBUG
+                    if ProcessInfo.processInfo.arguments.contains("--ui-testing-reduce-motion") {
+                        reduceMotion = true
+                    }
+                    #endif
+                }
+                .transformEnvironment(\.colorSchemeContrast) { contrast in
+                    #if DEBUG
+                    if ProcessInfo.processInfo.arguments.contains("--ui-testing-increased-contrast") {
+                        contrast = .increased
+                    }
+                    #endif
+                }
         }
         .defaultSize(width: WindowLayout.defaultWidth, height: WindowLayout.defaultHeight)
         .defaultPosition(.center)

--- a/Microfiche/Services/AccessibilitySupport.swift
+++ b/Microfiche/Services/AccessibilitySupport.swift
@@ -1,0 +1,80 @@
+//
+//  AccessibilitySupport.swift
+//  Microfiche
+//
+
+import AppKit
+import Foundation
+
+enum MicroficheAccessibility {
+    static func selectionAnnouncement(
+        selectedFiles: [ImageFile],
+        focusedFile: ImageFile?
+    ) -> String {
+        switch selectedFiles.count {
+        case 0:
+            return "No images selected"
+        case 1:
+            return "\((focusedFile ?? selectedFiles[0]).name) selected"
+        default:
+            if let focusedFile {
+                return "\(selectedFiles.count) images selected, \(focusedFile.name) focused"
+            }
+            return "\(selectedFiles.count) images selected"
+        }
+    }
+
+    static func dropAnnouncement(addedCount: Int, contactSheetName: String) -> String {
+        switch addedCount {
+        case 0:
+            return "No new images added to \(contactSheetName)"
+        case 1:
+            return "1 image added to \(contactSheetName)"
+        default:
+            return "\(addedCount) images added to \(contactSheetName)"
+        }
+    }
+
+    static func imageLoadAnnouncement(
+        phase: ImageLoadPhase,
+        fileName: String
+    ) -> String? {
+        switch phase {
+        case .idle:
+            return nil
+        case .placeholder:
+            return "\(fileName) is stored in iCloud and needs to be downloaded"
+        case .downloading:
+            return "Downloading \(fileName) from iCloud"
+        case .retrying:
+            return "Retrying \(fileName)"
+        case .loading:
+            return "Loading \(fileName)"
+        case .loaded:
+            return nil
+        case .failed(let message):
+            return "\(fileName) unavailable. \(message)"
+        case .cancelled:
+            return "Loading \(fileName) cancelled"
+        }
+    }
+
+    @MainActor
+    static func announce(_ message: String, priority: NSAccessibilityPriorityLevel = .medium) {
+        guard !message.isEmpty else { return }
+        let element: Any
+        if let window = NSApp.mainWindow ?? NSApp.keyWindow {
+            element = window
+        } else {
+            element = NSApp
+        }
+        NSAccessibility.post(
+            element: element,
+            notification: .announcementRequested,
+            userInfo: [
+                .announcement: message,
+                .priority: priority.rawValue
+            ]
+        )
+    }
+}

--- a/Microfiche/Views/ImageDetailView.swift
+++ b/Microfiche/Views/ImageDetailView.swift
@@ -14,6 +14,7 @@ import SwiftUI
 struct ImageDetailView: View {
     let file: ImageFile
     @Binding var isMetadataPresented: Bool
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     var body: some View {
         extendedImageCanvas
@@ -32,15 +33,23 @@ struct ImageDetailView: View {
 
                 ToolbarItemGroup {
                     Button {
-                        isMetadataPresented.toggle()
+                        withAnimation(MicroficheMotion.panel(reducedMotion: reduceMotion)) {
+                            isMetadataPresented.toggle()
+                        }
                     } label: {
                         Image(systemName: "sidebar.right")
                     }
                     .help(isMetadataPresented ? "Hide Info" : "Show Info")
+                    .accessibilityLabel(
+                        isMetadataPresented ? "Hide inspector" : "Show inspector"
+                    )
+                    .accessibilityIdentifier("detail.inspector.toggle")
 
                     ShareLink(item: file.url) {
                         Image(systemName: "square.and.arrow.up")
                     }
+                    .accessibilityLabel("Share \(file.name)")
+                    .accessibilityIdentifier("detail.share")
 
                     Menu {
                         Button("Reveal in Finder") {
@@ -54,6 +63,8 @@ struct ImageDetailView: View {
                         Image(systemName: "ellipsis")
                     }
                     .help("More")
+                    .accessibilityLabel("More actions for \(file.name)")
+                    .accessibilityIdentifier("detail.more")
                 }
             }
     }
@@ -85,6 +96,7 @@ struct ImageDetailView: View {
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .padding(28)
         }
+        .accessibilityLabel(file.name)
         .accessibilityIdentifier("image.detail")
     }
 
@@ -229,6 +241,10 @@ struct ImageMetadataInspectorView: View {
                 _ = await writer.apply(.replaceComments(commentsToSave), to: urls)
                 _ = await writer.apply(.replaceWhereFrom(sourceToSave), to: urls)
             }
+        }
+        .onChange(of: saveError) { _, error in
+            guard let error else { return }
+            MicroficheAccessibility.announce(error, priority: .high)
         }
         .microficheInspectorContentChrome()
         .accessibilityIdentifier("inspector.content")
@@ -376,6 +392,9 @@ struct ImageMetadataInspectorView: View {
                 .buttonStyle(.borderless)
                 .disabled(isSaving)
                 .help(isEditing.wrappedValue ? "Replace \(title)" : "Replace \(title)")
+                .accessibilityLabel(
+                    isEditing.wrappedValue ? "Apply \(title)" : "Edit \(title)"
+                )
                 .accessibilityIdentifier(replaceIdentifier)
             }
 
@@ -383,6 +402,7 @@ struct ImageMetadataInspectorView: View {
                 if isMultiline {
                     TextEditor(text: draft)
                         .frame(minHeight: 88)
+                        .accessibilityLabel(title)
                         .overlay {
                             RoundedRectangle(cornerRadius: 6)
                                 .strokeBorder(Color(NSColor.separatorColor))
@@ -390,6 +410,7 @@ struct ImageMetadataInspectorView: View {
                 } else {
                     TextField("Enter source", text: draft)
                         .textFieldStyle(.roundedBorder)
+                        .accessibilityLabel(title)
                         .onSubmit {
                             onReplace(draft.wrappedValue)
                             isEditing.wrappedValue = false
@@ -640,6 +661,7 @@ struct EditableChipSection: View {
                 }
                 .buttonStyle(.borderless)
                 .help(isEditing ? "Done" : "Add \(itemName)")
+                .accessibilityLabel(isEditing ? "Finish editing \(title)" : "Add \(itemName)")
             }
 
             if isEditing {
@@ -734,5 +756,8 @@ struct InfoRow: View {
                 .textSelection(.enabled)
             Spacer(minLength: 0)
         }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(label)
+        .accessibilityValue(value)
     }
 }

--- a/Microfiche/Views/ImageDetailView.swift
+++ b/Microfiche/Views/ImageDetailView.swift
@@ -15,6 +15,7 @@ struct ImageDetailView: View {
     let file: ImageFile
     @Binding var isMetadataPresented: Bool
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
 
     var body: some View {
         extendedImageCanvas
@@ -71,7 +72,9 @@ struct ImageDetailView: View {
 
     @ViewBuilder
     private var extendedImageCanvas: some View {
-        if #available(macOS 26.0, *) {
+        if reduceTransparency {
+            imageCanvas
+        } else if #available(macOS 26.0, *) {
             imageCanvas.backgroundExtensionEffect()
         } else {
             imageCanvas
@@ -324,6 +327,7 @@ struct ImageMetadataInspectorView: View {
                         .foregroundStyle(.secondary)
                 }
                 .font(.caption)
+                .accessibilityIdentifier("inspector.technical.loading")
 
             case .available(let metadata):
                 VStack(alignment: .leading, spacing: 6) {
@@ -337,6 +341,7 @@ struct ImageMetadataInspectorView: View {
                     .font(.caption)
                     .foregroundStyle(.secondary)
                     .italic()
+                    .accessibilityIdentifier("inspector.technical.empty")
 
             case .failed(let message):
                 VStack(alignment: .leading, spacing: 8) {
@@ -348,7 +353,9 @@ struct ImageMetadataInspectorView: View {
                         technicalMetadataReloadID = UUID()
                     }
                     .controlSize(.small)
+                    .accessibilityIdentifier("inspector.technical.retry")
                 }
+                .accessibilityIdentifier("inspector.technical.failed")
             }
         }
     }
@@ -403,6 +410,7 @@ struct ImageMetadataInspectorView: View {
                     TextEditor(text: draft)
                         .frame(minHeight: 88)
                         .accessibilityLabel(title)
+                        .accessibilityIdentifier("\(replaceIdentifier).editor")
                         .overlay {
                             RoundedRectangle(cornerRadius: 6)
                                 .strokeBorder(Color(NSColor.separatorColor))
@@ -411,6 +419,7 @@ struct ImageMetadataInspectorView: View {
                     TextField("Enter source", text: draft)
                         .textFieldStyle(.roundedBorder)
                         .accessibilityLabel(title)
+                        .accessibilityIdentifier("\(replaceIdentifier).editor")
                         .onSubmit {
                             onReplace(draft.wrappedValue)
                             isEditing.wrappedValue = false
@@ -429,6 +438,7 @@ struct ImageMetadataInspectorView: View {
                 }
                 .buttonStyle(.borderless)
                 .controlSize(.small)
+                .accessibilityIdentifier("\(replaceIdentifier).cancel")
             } else {
                 Text(displayText(for: field, placeholder: placeholder))
                     .foregroundStyle(fieldDisplayIsPlaceholder(field) ? .secondary : .primary)

--- a/Microfiche/Views/KeyboardEventHandlingView.swift
+++ b/Microfiche/Views/KeyboardEventHandlingView.swift
@@ -7,6 +7,15 @@
 
 import SwiftUI
 
+enum LibraryKeyboardFocusPolicy {
+    static func shouldHandleLibraryKeys(
+        isVoiceOverRunning: Bool,
+        isTextInputFirstResponder: Bool
+    ) -> Bool {
+        !isVoiceOverRunning && !isTextInputFirstResponder
+    }
+}
+
 struct KeyboardEventHandlingView: NSViewRepresentable {
     var onDeletePressed: (_ bypassConfirmation: Bool) -> Void
     var onEscapePressed: () -> Void
@@ -44,11 +53,21 @@ struct KeyboardEventHandlingView: NSViewRepresentable {
         override var acceptsFirstResponder: Bool { true }
 
         func claimFirstResponderIfAppropriate() {
-            guard let window, !(window.firstResponder is NSTextView) else { return }
+            guard let window else { return }
+            let isTextInput = window.firstResponder is NSTextView
+                || window.firstResponder is NSTextField
+            guard LibraryKeyboardFocusPolicy.shouldHandleLibraryKeys(
+                isVoiceOverRunning: NSWorkspace.shared.isVoiceOverEnabled,
+                isTextInputFirstResponder: isTextInput
+            ) else { return }
             window.makeFirstResponder(self)
         }
 
         override func keyDown(with event: NSEvent) {
+            guard !NSWorkspace.shared.isVoiceOverEnabled else {
+                super.keyDown(with: event)
+                return
+            }
             switch event.keyCode {
             case 51, 117: // 51: Delete, 117: Forward Delete
                 let bypass = event.modifierFlags.contains(.command) || event.modifierFlags.contains(.shift)

--- a/Microfiche/Views/KeyboardEventHandlingView.swift
+++ b/Microfiche/Views/KeyboardEventHandlingView.swift
@@ -15,6 +15,7 @@ struct KeyboardEventHandlingView: NSViewRepresentable {
 
     func makeNSView(context: Context) -> NSView {
         let view = KeyView()
+        view.setAccessibilityElement(false)
         view.onDeletePressed = onDeletePressed
         view.onEscapePressed = onEscapePressed
         view.onSpacebarPressed = onSpacebarPressed

--- a/Microfiche/Views/LiquidGlassDesign.swift
+++ b/Microfiche/Views/LiquidGlassDesign.swift
@@ -18,6 +18,10 @@ enum MicroficheMotion {
     /// Fluid movement for structural panels that resize the content canvas.
     static let panel = Animation.spring(response: 0.32, dampingFraction: 0.9)
 
+    static func isEnabled(reducedMotion: Bool) -> Bool {
+        !reducedMotion
+    }
+
     static func snap(reducedMotion: Bool) -> Animation? {
         reducedMotion ? nil : snap
     }
@@ -28,6 +32,20 @@ enum MicroficheMotion {
 
     static func panel(reducedMotion: Bool) -> Animation? {
         reducedMotion ? nil : panel
+    }
+}
+
+enum MicroficheContrast {
+    static func selectionFillOpacity(increased: Bool) -> Double {
+        increased ? 0.22 : 0.1
+    }
+
+    static func selectionStrokeOpacity(increased: Bool) -> Double {
+        increased ? 1 : 0.9
+    }
+
+    static func selectionStrokeWidth(increased: Bool) -> CGFloat {
+        increased ? 3 : 2
     }
 }
 
@@ -61,21 +79,51 @@ extension View {
     }
 
     /// Crisp content selection without glow or lift — planted, high-contrast framing.
-    @ViewBuilder
-    func contentSelectionChrome(isSelected: Bool, cornerRadius: CGFloat = 8) -> some View {
-        let shape = RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+    func contentSelectionChrome(
+        isSelected: Bool,
+        isFocused: Bool = false,
+        cornerRadius: CGFloat = 8
+    ) -> some View {
+        modifier(ContentSelectionChromeModifier(
+            isSelected: isSelected,
+            isFocused: isFocused,
+            cornerRadius: cornerRadius
+        ))
+    }
+}
 
-        if isSelected {
-            self
-                .padding(3)
-                .background(Color.accentColor.opacity(0.1), in: shape)
-                .overlay {
-                    shape
-                        .strokeBorder(Color.accentColor.opacity(0.9), lineWidth: 2)
+private struct ContentSelectionChromeModifier: ViewModifier {
+    let isSelected: Bool
+    let isFocused: Bool
+    let cornerRadius: CGFloat
+    @Environment(\.colorSchemeContrast) private var contrast
+
+    func body(content: Content) -> some View {
+        let shape = RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+        let increased = contrast == .increased
+
+        content
+            .padding(3)
+            .background(
+                isSelected
+                    ? Color.accentColor.opacity(
+                        MicroficheContrast.selectionFillOpacity(increased: increased)
+                    )
+                    : Color.clear,
+                in: shape
+            )
+            .overlay {
+                if isSelected || isFocused {
+                    shape.strokeBorder(
+                        Color.accentColor.opacity(
+                            MicroficheContrast.selectionStrokeOpacity(increased: increased)
+                        ),
+                        lineWidth: isFocused
+                            ? MicroficheContrast.selectionStrokeWidth(increased: increased)
+                            : (increased ? 2 : 1.5)
+                    )
                 }
-        } else {
-            self.padding(3)
-        }
+            }
     }
 }
 
@@ -85,36 +133,73 @@ extension View {
     /// Flat hover highlight for grid cells — tint only, no scale or shadow lift.
     @ViewBuilder
     func contentHoverDynamics(isHovered: Bool, isSelected: Bool, cornerRadius: CGFloat = 8) -> some View {
-        let shape = RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
-
-        self
-            .background {
-                if isHovered && !isSelected {
-                    shape.fill(Color.primary.opacity(0.045))
-                }
-            }
-            .overlay {
-                if isHovered && !isSelected {
-                    shape.strokeBorder(Color.primary.opacity(0.08), lineWidth: 1)
-                }
-            }
-            .animation(MicroficheMotion.snap, value: isHovered)
+        modifier(ContentHoverModifier(
+            isHovered: isHovered,
+            isSelected: isSelected,
+            cornerRadius: cornerRadius
+        ))
     }
 
     /// Subtle background tint for sidebar/list rows on hover.
     @ViewBuilder
     func sidebarHoverBackground(isHovered: Bool, isSelected: Bool, cornerRadius: CGFloat = 6) -> some View {
-        let shape = RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+        modifier(SidebarHoverModifier(
+            isHovered: isHovered,
+            isSelected: isSelected,
+            cornerRadius: cornerRadius
+        ))
+    }
+}
 
-        self
+private struct ContentHoverModifier: ViewModifier {
+    let isHovered: Bool
+    let isSelected: Bool
+    let cornerRadius: CGFloat
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(\.colorSchemeContrast) private var contrast
+
+    func body(content: Content) -> some View {
+        let shape = RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+        let increased = contrast == .increased
+
+        content
             .background {
                 if isHovered && !isSelected {
-                    shape.fill(Color.primary.opacity(0.05))
-                } else if isHovered && isSelected {
-                    shape.fill(Color.accentColor.opacity(0.22))
+                    shape.fill(Color.primary.opacity(increased ? 0.1 : 0.045))
                 }
             }
-            .animation(MicroficheMotion.snap, value: isHovered)
+            .overlay {
+                if isHovered && !isSelected {
+                    shape.strokeBorder(
+                        Color.primary.opacity(increased ? 0.3 : 0.08),
+                        lineWidth: increased ? 2 : 1
+                    )
+                }
+            }
+            .animation(MicroficheMotion.snap(reducedMotion: reduceMotion), value: isHovered)
+    }
+}
+
+private struct SidebarHoverModifier: ViewModifier {
+    let isHovered: Bool
+    let isSelected: Bool
+    let cornerRadius: CGFloat
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(\.colorSchemeContrast) private var contrast
+
+    func body(content: Content) -> some View {
+        let shape = RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+        let increased = contrast == .increased
+
+        content
+            .background {
+                if isHovered && !isSelected {
+                    shape.fill(Color.primary.opacity(increased ? 0.1 : 0.05))
+                } else if isHovered && isSelected {
+                    shape.fill(Color.accentColor.opacity(increased ? 0.3 : 0.22))
+                }
+            }
+            .animation(MicroficheMotion.snap(reducedMotion: reduceMotion), value: isHovered)
     }
 }
 

--- a/Microfiche/Views/LiquidGlassDesign.swift
+++ b/Microfiche/Views/LiquidGlassDesign.swift
@@ -208,6 +208,8 @@ private struct SidebarHoverModifier: ViewModifier {
 struct LiquidGlassPanel<Content: View>: View {
     let cornerRadius: CGFloat
     let content: Content
+    @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
+    @Environment(\.colorSchemeContrast) private var contrast
 
     init(cornerRadius: CGFloat = 14, @ViewBuilder content: () -> Content) {
         self.cornerRadius = cornerRadius
@@ -217,7 +219,11 @@ struct LiquidGlassPanel<Content: View>: View {
     var body: some View {
         let shape = RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
 
-        if #available(macOS 26.0, *) {
+        if reduceTransparency || contrast == .increased {
+            content
+                .background(Color(NSColor.controlBackgroundColor), in: shape)
+                .overlay(shape.strokeBorder(Color(NSColor.separatorColor), lineWidth: 1))
+        } else if #available(macOS 26.0, *) {
             content
                 .background {
                     shape
@@ -242,8 +248,14 @@ private struct SidebarSurface: View {
 }
 
 private struct InspectorReadingSurface: View {
+    @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
+    @Environment(\.colorSchemeContrast) private var contrast
+
     var body: some View {
-        if #available(macOS 26.0, *) {
+        if reduceTransparency || contrast == .increased {
+            Color(NSColor.controlBackgroundColor)
+                .ignoresSafeArea()
+        } else if #available(macOS 26.0, *) {
             // Keep a trace of the system glass tint without allowing extended
             // image colors to compete with metadata text and controls.
             Color(NSColor.windowBackgroundColor)

--- a/Microfiche/Views/MainContentView.swift
+++ b/Microfiche/Views/MainContentView.swift
@@ -272,16 +272,32 @@ private struct FloatingViewModeControl: View {
 }
 
 private extension View {
-    @ViewBuilder
     func floatingViewModeGlass() -> some View {
-        if #available(macOS 26.0, *) {
-            self.glassEffect(.regular.interactive(), in: Capsule())
+        modifier(FloatingViewModeGlassModifier())
+    }
+}
+
+private struct FloatingViewModeGlassModifier: ViewModifier {
+    @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
+    @Environment(\.colorSchemeContrast) private var contrast
+
+    @ViewBuilder
+    func body(content: Content) -> some View {
+        if reduceTransparency || contrast == .increased {
+            content
+                .background(Color(NSColor.controlBackgroundColor), in: Capsule())
+                .overlay {
+                    Capsule()
+                        .strokeBorder(Color(NSColor.separatorColor), lineWidth: 1)
+                }
+        } else if #available(macOS 26.0, *) {
+            content.glassEffect(.regular.interactive(), in: Capsule())
         } else {
-            self
+            content
                 .background(.ultraThinMaterial, in: Capsule())
                 .overlay {
                     Capsule()
-                        .stroke(Color.white.opacity(0.3), lineWidth: 0.5)
+                        .stroke(Color(NSColor.separatorColor), lineWidth: 0.5)
                 }
         }
     }
@@ -534,6 +550,7 @@ struct GridCell: View {
     let onAddToContactSheet: (UUID, URL) -> Void
     let onArchive: (ImageFile) -> Void
     @State private var isHovered = false
+    @AccessibilityFocusState private var isAccessibilityFocused: Bool
 
     var body: some View {
         FileThumbnailView(
@@ -545,7 +562,10 @@ struct GridCell: View {
             onRename: onRename
         )
         .frame(width: size, height: size / aspectRatio)
-        .contentSelectionChrome(isSelected: isSelected, isFocused: isFocused)
+        .contentSelectionChrome(
+            isSelected: isSelected,
+            isFocused: isFocused || isAccessibilityFocused
+        )
         .contentHoverDynamics(
             isHovered: isResizing ? false : isHovered,
             isSelected: isSelected
@@ -576,8 +596,11 @@ struct GridCell: View {
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(file.name)
         .accessibilityValue(isSelected ? "Selected" : "Not selected")
-        .accessibilityAddTraits(isSelected ? [.isSelected] : [])
+        .accessibilityAddTraits(
+            isSelected ? [.isButton, .isSelected] : [.isButton]
+        )
         .accessibilityIdentifier("image.\(file.name)")
+        .accessibilityFocused($isAccessibilityFocused)
         .accessibilityAction(.default) {
             onSelectImage(file.id)
         }
@@ -641,6 +664,7 @@ struct ImageListView: View {
                 }
             }
         }
+        .accessibilityIdentifier("image.list")
     }
 }
 
@@ -658,6 +682,7 @@ struct ImageListRow: View {
     let onArchive: (ImageFile) -> Void
     @State private var isHovered = false
     @Environment(\.colorSchemeContrast) private var contrast
+    @AccessibilityFocusState private var isAccessibilityFocused: Bool
 
     var body: some View {
         HStack(spacing: 12) {
@@ -687,13 +712,17 @@ struct ImageListRow: View {
                 .fill(isSelected ? Color.accentColor.opacity(0.12) : Color.clear)
         }
         .overlay {
-            if isSelected || isFocused {
+            if isSelected || isFocused || isAccessibilityFocused {
                 RoundedRectangle(cornerRadius: 7, style: .continuous)
                     .strokeBorder(
                         Color.accentColor.opacity(
-                            contrast == .increased ? 1 : (isFocused ? 0.95 : 0.55)
+                            contrast == .increased
+                                ? 1
+                                : ((isFocused || isAccessibilityFocused) ? 0.95 : 0.55)
                         ),
-                        lineWidth: contrast == .increased ? 3 : (isFocused ? 2 : 1.5)
+                        lineWidth: contrast == .increased
+                            ? 3
+                            : ((isFocused || isAccessibilityFocused) ? 2 : 1.5)
                     )
             }
         }
@@ -717,8 +746,11 @@ struct ImageListRow: View {
         .accessibilityElement(children: .combine)
         .accessibilityLabel(file.name)
         .accessibilityValue(isSelected ? "Selected" : "Not selected")
-        .accessibilityAddTraits(isSelected ? [.isSelected] : [])
+        .accessibilityAddTraits(
+            isSelected ? [.isButton, .isSelected] : [.isButton]
+        )
         .accessibilityIdentifier("image.\(file.name)")
+        .accessibilityFocused($isAccessibilityFocused)
         .accessibilityAction(.default) {
             onSelectImage(file.id)
         }

--- a/Microfiche/Views/MainContentView.swift
+++ b/Microfiche/Views/MainContentView.swift
@@ -108,6 +108,7 @@ struct MainContentView: View {
     let isResizingGrid: Bool
     @Binding var gridColumnCount: Int
     @Binding var selectedImageFileIDs: Set<UUID>
+    let focusedImageFileID: UUID?
     let onSelectImage: (UUID) -> Void
     let onDoubleClickImage: (UUID) -> Void
     @Binding var scrollToID: UUID?
@@ -143,6 +144,7 @@ struct MainContentView: View {
                             ImageGridView(
                                 imageFiles: imageFiles,
                                 selectedImageFileIDs: $selectedImageFileIDs,
+                                focusedImageFileID: focusedImageFileID,
                                 onSelectImage: onSelectImage,
                                 onDoubleClickImage: onDoubleClickImage,
                                 thumbnailSize: gridThumbnailSize,
@@ -158,6 +160,7 @@ struct MainContentView: View {
                             ImageListView(
                                 imageFiles: imageFiles,
                                 selectedImageFileIDs: $selectedImageFileIDs,
+                                focusedImageFileID: focusedImageFileID,
                                 onSelectImage: onSelectImage,
                                 onDoubleClickImage: onDoubleClickImage,
                                 scrollToID: $scrollToID,
@@ -219,6 +222,7 @@ struct MainContentView: View {
 private struct FloatingViewModeControl: View {
     @Binding var selection: ViewMode
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(\.colorSchemeContrast) private var contrast
 
     var body: some View {
         HStack(spacing: 2) {
@@ -251,7 +255,17 @@ private struct FloatingViewModeControl: View {
         }
         .padding(3)
         .floatingViewModeGlass()
-        .shadow(color: Color.black.opacity(0.08), radius: 6, y: 2)
+        .overlay {
+            if contrast == .increased {
+                Capsule()
+                    .strokeBorder(Color.primary, lineWidth: 1)
+            }
+        }
+        .shadow(
+            color: contrast == .increased ? .clear : Color.black.opacity(0.08),
+            radius: 6,
+            y: 2
+        )
         .accessibilityElement(children: .contain)
         .accessibilityLabel("View mode")
     }
@@ -306,6 +320,9 @@ private struct EmptyLibraryStateView: View {
             }
         }
         .padding(.horizontal, 24)
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel(emptyStateTitle)
+        .accessibilityValue(emptyStateMessage)
         .accessibilityIdentifier(
             unavailableLocation == nil ? "library.empty" : "library-location.unavailable"
         )
@@ -362,6 +379,7 @@ private struct ContactSheetDropOverlay: View {
                     .background(.regularMaterial, in: Capsule())
             }
             .allowsHitTesting(false)
+            .accessibilityHidden(true)
             .accessibilityIdentifier("contact-sheet-drop-target")
     }
 }
@@ -392,6 +410,7 @@ struct ImageGridView: View {
 
     let imageFiles: [ImageFile]
     @Binding var selectedImageFileIDs: Set<UUID>
+    let focusedImageFileID: UUID?
     let onSelectImage: (UUID) -> Void
     let onDoubleClickImage: (UUID) -> Void
     let thumbnailSize: CGFloat
@@ -402,6 +421,7 @@ struct ImageGridView: View {
     let contactSheets: [ContactSheet]
     let onAddToContactSheet: (UUID, URL) -> Void
     let onArchive: (ImageFile) -> Void
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     var body: some View {
         GeometryReader { geometry in
@@ -419,6 +439,7 @@ struct ImageGridView: View {
                             GridCell(
                                 file: file,
                                 isSelected: selectedImageFileIDs.contains(file.id),
+                                isFocused: focusedImageFileID == file.id,
                                 size: thumbnailSize,
                                 isResizing: isResizing,
                                 aspectRatio: Layout.aspectRatio,
@@ -460,7 +481,7 @@ struct ImageGridView: View {
                 }
                 .onChange(of: scrollToID) { _, newID in
                     if let id = newID {
-                        withAnimation(MicroficheMotion.snap) {
+                        withAnimation(MicroficheMotion.snap(reducedMotion: reduceMotion)) {
                             proxy.scrollTo(id, anchor: .center)
                         }
                         DispatchQueue.main.async { scrollToID = nil }
@@ -474,7 +495,10 @@ struct ImageGridView: View {
                 transaction.disablesAnimations = true
             }
         }
-        .animation(isResizing ? nil : MicroficheMotion.snap, value: thumbnailSize)
+        .animation(
+            isResizing ? nil : MicroficheMotion.snap(reducedMotion: reduceMotion),
+            value: thumbnailSize
+        )
         .accessibilityIdentifier("image.grid")
     }
 
@@ -499,6 +523,7 @@ struct ImageGridView: View {
 struct GridCell: View {
     let file: ImageFile
     let isSelected: Bool
+    let isFocused: Bool
     let size: CGFloat
     let isResizing: Bool
     let aspectRatio: CGFloat
@@ -520,7 +545,7 @@ struct GridCell: View {
             onRename: onRename
         )
         .frame(width: size, height: size / aspectRatio)
-        .contentSelectionChrome(isSelected: isSelected)
+        .contentSelectionChrome(isSelected: isSelected, isFocused: isFocused)
         .contentHoverDynamics(
             isHovered: isResizing ? false : isHovered,
             isSelected: isSelected
@@ -553,6 +578,12 @@ struct GridCell: View {
         .accessibilityValue(isSelected ? "Selected" : "Not selected")
         .accessibilityAddTraits(isSelected ? [.isSelected] : [])
         .accessibilityIdentifier("image.\(file.name)")
+        .accessibilityAction(.default) {
+            onSelectImage(file.id)
+        }
+        .accessibilityAction(named: "Open Image") {
+            onDoubleClickImage(file.id)
+        }
     }
 }
 
@@ -561,6 +592,7 @@ struct GridCell: View {
 struct ImageListView: View {
     let imageFiles: [ImageFile]
     @Binding var selectedImageFileIDs: Set<UUID>
+    let focusedImageFileID: UUID?
     let onSelectImage: (UUID) -> Void
     let onDoubleClickImage: (UUID) -> Void
     @Binding var scrollToID: UUID?
@@ -568,6 +600,7 @@ struct ImageListView: View {
     let contactSheets: [ContactSheet]
     let onAddToContactSheet: (UUID, URL) -> Void
     let onArchive: (ImageFile) -> Void
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     var body: some View {
         ScrollViewReader { proxy in
@@ -577,6 +610,7 @@ struct ImageListView: View {
                         ImageListRow(
                             file: file,
                             isSelected: selectedImageFileIDs.contains(file.id),
+                            isFocused: focusedImageFileID == file.id,
                             onSelectImage: onSelectImage,
                             onDoubleClickImage: onDoubleClickImage,
                             onRename: onRename,
@@ -600,7 +634,7 @@ struct ImageListView: View {
             }
             .onChange(of: scrollToID) { _, newID in
                 if let id = newID {
-                    withAnimation(MicroficheMotion.snap) {
+                    withAnimation(MicroficheMotion.snap(reducedMotion: reduceMotion)) {
                         proxy.scrollTo(id, anchor: .center)
                     }
                     DispatchQueue.main.async { scrollToID = nil }
@@ -615,6 +649,7 @@ struct ImageListView: View {
 struct ImageListRow: View {
     let file: ImageFile
     let isSelected: Bool
+    let isFocused: Bool
     let onSelectImage: (UUID) -> Void
     let onDoubleClickImage: (UUID) -> Void
     let onRename: (URL, String) -> Void
@@ -622,6 +657,7 @@ struct ImageListRow: View {
     let onAddToContactSheet: (UUID, URL) -> Void
     let onArchive: (ImageFile) -> Void
     @State private var isHovered = false
+    @Environment(\.colorSchemeContrast) private var contrast
 
     var body: some View {
         HStack(spacing: 12) {
@@ -651,9 +687,14 @@ struct ImageListRow: View {
                 .fill(isSelected ? Color.accentColor.opacity(0.12) : Color.clear)
         }
         .overlay {
-            if isSelected {
+            if isSelected || isFocused {
                 RoundedRectangle(cornerRadius: 7, style: .continuous)
-                    .strokeBorder(Color.accentColor.opacity(0.55), lineWidth: 1.5)
+                    .strokeBorder(
+                        Color.accentColor.opacity(
+                            contrast == .increased ? 1 : (isFocused ? 0.95 : 0.55)
+                        ),
+                        lineWidth: contrast == .increased ? 3 : (isFocused ? 2 : 1.5)
+                    )
             }
         }
         .sidebarHoverBackground(isHovered: isHovered, isSelected: isSelected, cornerRadius: 7)
@@ -678,6 +719,12 @@ struct ImageListRow: View {
         .accessibilityValue(isSelected ? "Selected" : "Not selected")
         .accessibilityAddTraits(isSelected ? [.isSelected] : [])
         .accessibilityIdentifier("image.\(file.name)")
+        .accessibilityAction(.default) {
+            onSelectImage(file.id)
+        }
+        .accessibilityAction(named: "Open Image") {
+            onDoubleClickImage(file.id)
+        }
     }
 }
 

--- a/Microfiche/Views/PreviewView.swift
+++ b/Microfiche/Views/PreviewView.swift
@@ -36,5 +36,11 @@ struct PreviewView: View {
                 .frame(width: geometry.size.width * 0.75, height: geometry.size.height * 0.75)
             }
         }
+        .accessibilityElement(children: .contain)
+        .accessibilityAddTraits(.isModal)
+        .accessibilityLabel("Quick preview of \(file.name)")
+        .accessibilityAction(named: "Close Preview") {
+            onDismiss()
+        }
     }
 }

--- a/Microfiche/Views/PreviewView.swift
+++ b/Microfiche/Views/PreviewView.swift
@@ -39,6 +39,8 @@ struct PreviewView: View {
         .accessibilityElement(children: .contain)
         .accessibilityAddTraits(.isModal)
         .accessibilityLabel("Quick preview of \(file.name)")
+        .accessibilityHint("Press Escape to close")
+        .accessibilityIdentifier("preview.quick")
         .accessibilityAction(named: "Close Preview") {
             onDismiss()
         }

--- a/Microfiche/Views/RecoverablePreviewImage.swift
+++ b/Microfiche/Views/RecoverablePreviewImage.swift
@@ -26,6 +26,16 @@ struct RecoverablePreviewImage: View {
         .task(id: url) {
             model.prepare(url: url)
         }
+        .onChange(of: model.state.phase) { _, phase in
+            guard let message = MicroficheAccessibility.imageLoadAnnouncement(
+                phase: phase,
+                fileName: url.lastPathComponent
+            ) else { return }
+            MicroficheAccessibility.announce(
+                message,
+                priority: phase.isAccessibilityFailure ? .high : .medium
+            )
+        }
         .onDisappear {
             model.cancel()
         }
@@ -93,5 +103,17 @@ struct RecoverablePreviewImage: View {
         }
         .frame(maxWidth: 320)
         .padding()
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel(title)
+        .accessibilityValue(message)
+    }
+}
+
+private extension ImageLoadPhase {
+    var isAccessibilityFailure: Bool {
+        if case .failed = self {
+            return true
+        }
+        return false
     }
 }

--- a/Microfiche/Views/SidebarView.swift
+++ b/Microfiche/Views/SidebarView.swift
@@ -333,8 +333,9 @@ private struct SidebarLocationRow: View {
         .contentShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
         .onHover { isHovered = $0 }
         .accessibilityElement(children: .combine)
-        .accessibilityLabel(volume.name)
+        .accessibilityLabel("\(volume.name), external drive")
         .accessibilityValue(volume.isConnected ? "Connected" : "Offline")
+        .accessibilityIdentifier("sidebar.location.\(volume.id)")
     }
 }
 

--- a/Microfiche/Views/SidebarView.swift
+++ b/Microfiche/Views/SidebarView.swift
@@ -213,6 +213,7 @@ private struct SidebarSection<Content: View>: View {
                 if let action {
                     SidebarAddButton(action: action)
                         .help(actionHelp ?? "Add")
+                        .accessibilityLabel(actionHelp ?? "Add")
                 }
             }
 
@@ -292,10 +293,15 @@ private struct SidebarStaticRow: View {
         .onTapGesture(perform: action)
         .accessibilityElement(children: .combine)
         .accessibilityValue(isSelected ? "Selected" : "")
-        .accessibilityAddTraits(isSelected ? [.isSelected] : [])
+        .accessibilityAddTraits(
+            isSelected ? [.isButton, .isSelected] : [.isButton]
+        )
         .accessibilityIdentifier(
             title == "All Images" ? "sidebar.all-images" : "sidebar.folder.\(title)"
         )
+        .accessibilityAction(.default) {
+            action()
+        }
     }
 }
 
@@ -326,6 +332,9 @@ private struct SidebarLocationRow: View {
         .sidebarRow(isSelected: false, isHovered: isHovered)
         .contentShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
         .onHover { isHovered = $0 }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(volume.name)
+        .accessibilityValue(volume.isConnected ? "Connected" : "Offline")
     }
 }
 
@@ -333,6 +342,8 @@ private struct SidebarRowModifier: ViewModifier {
     let isSelected: Bool
     let isHovered: Bool
     let isDropTargeted: Bool
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(\.colorSchemeContrast) private var contrast
 
     func body(content: Content) -> some View {
         content
@@ -347,22 +358,24 @@ private struct SidebarRowModifier: ViewModifier {
                 RoundedRectangle(cornerRadius: 8, style: .continuous)
                     .strokeBorder(borderColor, lineWidth: isDropTargeted ? 2 : 1)
             )
-            .animation(MicroficheMotion.snap, value: isSelected)
-            .animation(MicroficheMotion.snap, value: isHovered)
-            .animation(MicroficheMotion.snap, value: isDropTargeted)
+            .animation(MicroficheMotion.snap(reducedMotion: reduceMotion), value: isSelected)
+            .animation(MicroficheMotion.snap(reducedMotion: reduceMotion), value: isHovered)
+            .animation(MicroficheMotion.snap(reducedMotion: reduceMotion), value: isDropTargeted)
     }
 
     private var borderColor: Color {
         if isDropTargeted {
-            return Color.accentColor.opacity(0.82)
+            return Color.accentColor.opacity(contrast == .increased ? 1 : 0.82)
         }
 
-        return Color.clear
+        return isSelected && contrast == .increased
+            ? Color.accentColor
+            : Color.clear
     }
 
     private var rowBackground: Color {
         if isSelected {
-            return Color.primary.opacity(0.075)
+            return Color.primary.opacity(contrast == .increased ? 0.16 : 0.075)
         }
         if isHovered {
             return Color.primary.opacity(0.04)
@@ -495,8 +508,17 @@ struct ContactSheetSidebarItem: View {
         )
         .accessibilityElement(children: .combine)
         .accessibilityValue(isSelected ? "Selected" : "")
-        .accessibilityAddTraits(isSelected ? [.isSelected] : [])
+        .accessibilityAddTraits(
+            isSelected ? [.isButton, .isSelected] : [.isButton]
+        )
         .accessibilityIdentifier("contact-sheet-\(contactSheet.id.uuidString)-drop-target")
+        .accessibilityLabel(contactSheet.name)
+        .accessibilityHint("\(contactSheet.imageIDs.count) images. Accepts image drops.")
+        .accessibilityAction(.default) {
+            if !isEditing {
+                onSelect()
+            }
+        }
         .contextMenu {
             Button("Export PDF…") {
                 onExport()

--- a/MicroficheTests/MicroficheTests.swift
+++ b/MicroficheTests/MicroficheTests.swift
@@ -162,6 +162,25 @@ final class MicroficheTests: XCTestCase {
         XCTAssertNil(MicroficheMotion.panel(reducedMotion: true))
     }
 
+    func testLibraryKeyboardFocusPolicyYieldsToVoiceOverAndTextEditing() {
+        XCTAssertTrue(LibraryKeyboardFocusPolicy.shouldHandleLibraryKeys(
+            isVoiceOverRunning: false,
+            isTextInputFirstResponder: false
+        ))
+        XCTAssertFalse(LibraryKeyboardFocusPolicy.shouldHandleLibraryKeys(
+            isVoiceOverRunning: true,
+            isTextInputFirstResponder: false
+        ))
+        XCTAssertFalse(LibraryKeyboardFocusPolicy.shouldHandleLibraryKeys(
+            isVoiceOverRunning: false,
+            isTextInputFirstResponder: true
+        ))
+        XCTAssertFalse(LibraryKeyboardFocusPolicy.shouldHandleLibraryKeys(
+            isVoiceOverRunning: true,
+            isTextInputFirstResponder: true
+        ))
+    }
+
     func testIncreasedContrastStrengthensSelectionChrome() {
         XCTAssertGreaterThan(
             MicroficheContrast.selectionFillOpacity(increased: true),

--- a/MicroficheTests/MicroficheTests.swift
+++ b/MicroficheTests/MicroficheTests.swift
@@ -151,6 +151,92 @@ final class MicroficheTests: XCTestCase {
         XCTAssertGreaterThanOrEqual(GridThumbnailSizing.decodeSize, GridThumbnailSizing.defaultValue)
     }
 
+    func testReducedMotionDisablesEverySharedAnimationToken() {
+        XCTAssertTrue(MicroficheMotion.isEnabled(reducedMotion: false))
+        XCTAssertFalse(MicroficheMotion.isEnabled(reducedMotion: true))
+        XCTAssertNotNil(MicroficheMotion.snap(reducedMotion: false))
+        XCTAssertNotNil(MicroficheMotion.transition(reducedMotion: false))
+        XCTAssertNotNil(MicroficheMotion.panel(reducedMotion: false))
+        XCTAssertNil(MicroficheMotion.snap(reducedMotion: true))
+        XCTAssertNil(MicroficheMotion.transition(reducedMotion: true))
+        XCTAssertNil(MicroficheMotion.panel(reducedMotion: true))
+    }
+
+    func testIncreasedContrastStrengthensSelectionChrome() {
+        XCTAssertGreaterThan(
+            MicroficheContrast.selectionFillOpacity(increased: true),
+            MicroficheContrast.selectionFillOpacity(increased: false)
+        )
+        XCTAssertGreaterThan(
+            MicroficheContrast.selectionStrokeOpacity(increased: true),
+            MicroficheContrast.selectionStrokeOpacity(increased: false)
+        )
+        XCTAssertGreaterThan(
+            MicroficheContrast.selectionStrokeWidth(increased: true),
+            MicroficheContrast.selectionStrokeWidth(increased: false)
+        )
+    }
+
+    func testAccessibilityAnnouncementsCoverSelectionLoadingAndDropOutcomes() {
+        let first = ImageFile(url: URL(fileURLWithPath: "/Photos/first.jpg"))
+        let second = ImageFile(url: URL(fileURLWithPath: "/Photos/second.jpg"))
+
+        XCTAssertEqual(
+            MicroficheAccessibility.selectionAnnouncement(
+                selectedFiles: [],
+                focusedFile: nil
+            ),
+            "No images selected"
+        )
+        XCTAssertEqual(
+            MicroficheAccessibility.selectionAnnouncement(
+                selectedFiles: [first],
+                focusedFile: first
+            ),
+            "first.jpg selected"
+        )
+        XCTAssertEqual(
+            MicroficheAccessibility.selectionAnnouncement(
+                selectedFiles: [first, second],
+                focusedFile: second
+            ),
+            "2 images selected, second.jpg focused"
+        )
+        XCTAssertEqual(
+            MicroficheAccessibility.dropAnnouncement(
+                addedCount: 0,
+                contactSheetName: "Review"
+            ),
+            "No new images added to Review"
+        )
+        XCTAssertEqual(
+            MicroficheAccessibility.dropAnnouncement(
+                addedCount: 2,
+                contactSheetName: "Review"
+            ),
+            "2 images added to Review"
+        )
+        XCTAssertEqual(
+            MicroficheAccessibility.imageLoadAnnouncement(
+                phase: .failed("Network unavailable"),
+                fileName: "first.jpg"
+            ),
+            "first.jpg unavailable. Network unavailable"
+        )
+        XCTAssertNil(
+            MicroficheAccessibility.imageLoadAnnouncement(
+                phase: .loaded,
+                fileName: "first.jpg"
+            )
+        )
+        XCTAssertNil(
+            MicroficheAccessibility.imageLoadAnnouncement(
+                phase: .idle,
+                fileName: "first.jpg"
+            )
+        )
+    }
+
     func testGridNavigationMovesByCurrentColumnCount() {
         XCTAssertEqual(
             ImageNavigation.nextIndex(

--- a/MicroficheUITests/MicroficheUITests.swift
+++ b/MicroficheUITests/MicroficheUITests.swift
@@ -244,6 +244,73 @@ final class MicroficheUITests: XCTestCase {
     }
 
     @MainActor
+    func testAccessibleNamesValuesAndKeyboardFocusAcrossLibraryAndDetail() throws {
+        let app = configuredApp()
+        app.launch()
+
+        let first = fixtureImage(1, in: app)
+        let second = fixtureImage(2, in: app)
+        XCTAssertTrue(first.waitForExistence(timeout: 5))
+        XCTAssertEqual(first.label, "fixture-01.png")
+        XCTAssertEqual(first.value as? String, "Not selected")
+
+        app.typeKey(.rightArrow, modifierFlags: [])
+        XCTAssertTrue(first.isSelected)
+        XCTAssertEqual(first.value as? String, "Selected")
+        app.typeKey(.rightArrow, modifierFlags: [])
+        XCTAssertTrue(second.isSelected)
+        XCTAssertEqual(second.value as? String, "Selected")
+
+        second.doubleClick()
+        XCTAssertTrue(element("image.detail", in: app).waitForExistence(timeout: 2))
+        XCTAssertEqual(element("image.detail", in: app).label, "fixture-02.png")
+        XCTAssertTrue(
+            ["Hide inspector", "Show inspector"].contains(
+                element("detail.inspector.toggle", in: app).label
+            )
+        )
+        XCTAssertTrue(element("detail.share", in: app).exists)
+        XCTAssertEqual(
+            element("detail.more", in: app).label,
+            "More actions for fixture-02.png"
+        )
+    }
+
+    @MainActor
+    func testReduceMotionAndIncreasedContrastSupportRepeatedTransitions() throws {
+        let app = configuredApp(additionalArguments: [
+            "--ui-testing-reduce-motion",
+            "--ui-testing-increased-contrast"
+        ])
+        app.launch()
+
+        let first = fixtureImage(1, in: app)
+        XCTAssertTrue(first.waitForExistence(timeout: 5))
+
+        for _ in 0..<2 {
+            first.click()
+            XCTAssertTrue(first.isSelected)
+            app.typeKey(.space, modifierFlags: [])
+            XCTAssertTrue(
+                app.descendants(matching: .any)
+                    .matching(NSPredicate(
+                        format: "label == %@",
+                        "Quick preview of fixture-01.png"
+                    ))
+                    .firstMatch
+                    .waitForExistence(timeout: 2)
+            )
+            app.typeKey(.escape, modifierFlags: [])
+            XCTAssertTrue(first.waitForExistence(timeout: 2))
+
+            element("viewMode.list", in: app).click()
+            XCTAssertTrue(element("viewMode.list", in: app).isSelected)
+            element("viewMode.grid", in: app).click()
+            XCTAssertTrue(element("viewMode.grid", in: app).isSelected)
+        }
+    }
+
+    @MainActor
     func testLaunchPerformance() throws {
         if #available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 7.0, *) {
             measure(metrics: [XCTApplicationLaunchMetric()]) {
@@ -253,7 +320,7 @@ final class MicroficheUITests: XCTestCase {
     }
 
     @MainActor
-    private func configuredApp() -> XCUIApplication {
+    private func configuredApp(additionalArguments: [String] = []) -> XCUIApplication {
         let app = XCUIApplication()
         let defaultsSuite = "MicroficheUITests.\(UUID().uuidString)"
         app.launchArguments = [
@@ -263,7 +330,7 @@ final class MicroficheUITests: XCTestCase {
             "--ui-testing",
             "--ui-testing-fixtures",
             "--ui-testing-defaults-suite", defaultsSuite
-        ]
+        ] + additionalArguments
         return app
     }
 

--- a/MicroficheUITests/MicroficheUITests.swift
+++ b/MicroficheUITests/MicroficheUITests.swift
@@ -277,10 +277,37 @@ final class MicroficheUITests: XCTestCase {
     }
 
     @MainActor
-    func testReduceMotionAndIncreasedContrastSupportRepeatedTransitions() throws {
+    func testInspectorTextEditingKeepsKeyboardInputOutOfLibraryNavigation() throws {
+        let app = configuredApp()
+        app.launch()
+
+        let first = fixtureImage(1, in: app)
+        XCTAssertTrue(first.waitForExistence(timeout: 5))
+        first.click()
+        element("inspector.toggle", in: app).click()
+
+        let replace = element("inspector.replace-comments", in: app)
+        XCTAssertTrue(replace.waitForExistence(timeout: 2))
+
+        for attempt in 1...2 {
+            replace.click()
+            let editor = element("inspector.replace-comments.editor", in: app)
+            XCTAssertTrue(editor.waitForExistence(timeout: 2))
+            editor.click()
+            editor.typeText("Keyboard audit \(attempt)")
+            editor.typeKey(.rightArrow, modifierFlags: [])
+            XCTAssertTrue(first.isSelected)
+            element("inspector.replace-comments.cancel", in: app).click()
+            XCTAssertTrue(editor.waitForNonExistence(timeout: 2))
+        }
+    }
+
+    @MainActor
+    func testAccessibilityAppearancesSupportRepeatedTransitions() throws {
         let app = configuredApp(additionalArguments: [
             "--ui-testing-reduce-motion",
-            "--ui-testing-increased-contrast"
+            "--ui-testing-increased-contrast",
+            "--ui-testing-reduce-transparency"
         ])
         app.launch()
 
@@ -291,20 +318,14 @@ final class MicroficheUITests: XCTestCase {
             first.click()
             XCTAssertTrue(first.isSelected)
             app.typeKey(.space, modifierFlags: [])
-            XCTAssertTrue(
-                app.descendants(matching: .any)
-                    .matching(NSPredicate(
-                        format: "label == %@",
-                        "Quick preview of fixture-01.png"
-                    ))
-                    .firstMatch
-                    .waitForExistence(timeout: 2)
-            )
+            XCTAssertTrue(element("preview.quick", in: app).waitForExistence(timeout: 2))
             app.typeKey(.escape, modifierFlags: [])
+            XCTAssertTrue(element("preview.quick", in: app).waitForNonExistence(timeout: 2))
             XCTAssertTrue(first.waitForExistence(timeout: 2))
 
             element("viewMode.list", in: app).click()
             XCTAssertTrue(element("viewMode.list", in: app).isSelected)
+            XCTAssertTrue(element("image.list", in: app).exists)
             element("viewMode.grid", in: app).click()
             XCTAssertTrue(element("viewMode.grid", in: app).isSelected)
         }

--- a/design.md
+++ b/design.md
@@ -226,6 +226,4 @@ Disable animations while the grid size slider is dragging. Prefer `MicroficheMot
 
 ## Future Enhancements
 
-- Propagate Reduce Motion to all `MicroficheMotion` call sites
-- Keyboard focus ring that matches selection chrome
 - Retire or wire unused helpers (`microficheToolbarChrome`, `sidebarSelectionBackground`) deliberately


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add explicit keyboard and VoiceOver focus chrome plus accessible actions, roles, names, values, identifiers, and modal semantics across library, sidebar, detail, inspector, and preview surfaces
- make the global key handler yield to VoiceOver and text editors while preserving library keyboard navigation
- announce selection, image recovery, metadata failure, and contact-sheet drop outcomes without duplicate success chatter
- propagate Reduce Motion through every shared animation call site; strengthen Increased Contrast chrome; use solid fallbacks for Reduce Transparency
- add deterministic unit/UI coverage plus a documented macOS VoiceOver and appearance audit matrix

## Verification
- `git diff main...HEAD --check` — passed after the final audit follow-up
- independent Swift/API review found no remaining definite issues; `NSWorkspace.isVoiceOverEnabled` was verified against Apple’s current AppKit documentation
- `xcodebuild ... test` — unavailable on this Linux runner (`xcodebuild: command not found`)
- `xcodebuild ... build` — unavailable on this Linux runner (`xcodebuild: command not found`)
- no GitHub checks are configured for this branch

## Manual follow-up
The VoiceOver speech, visual focus/contrast, and Liquid Glass appearance matrix in `ACCESSIBILITY_AUDIT.md` requires macOS/Xcode and remains unchecked here.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a050e2-28df-78a2-b197-78fe7500b24b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a050e2-28df-78a2-b197-78fe7500b24b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

